### PR TITLE
mock(apps/cobalt): update version to 11.0

### DIFF
--- a/apps/cobalt/meta.json
+++ b/apps/cobalt/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "cobalt",
-  "version": "10.9",
+  "version": "11.0",
   "repo": "https://github.com/imputnet/cobalt",
-  "sha": "6fbc585155c5a7a732052ab6622b07b3389743df",
+  "sha": "71bb2de81a977f3ffabe02d55934ab476ffda425",
   "checkVer": {
     "type": "version",
     "file": "web/package.json",
@@ -19,8 +19,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=10.9",
-      "type=raw,value=6fbc585"
+      "type=raw,value=11.0",
+      "type=raw,value=71bb2de"
     ],
     "labels": {
       "title": "Cobalt",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update cobalt version to `11.0`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [cobalt](https://github.com/imputnet/cobalt) |
| **Version** | `10.9` → `11.0` |
| **Revision** | [`6fbc585`](https://github.com/imputnet/cobalt/commit/6fbc585155c5a7a732052ab6622b07b3389743df) → [`71bb2de`](https://github.com/imputnet/cobalt/commit/71bb2de81a977f3ffabe02d55934ab476ffda425) |
| **Latest Commit** | web/package: bump version to 11.0 |
| **Author** | wukko <me@wukko.me> |
| **Date** | 2025-05-29 22:10:37 |
| **Changes** | 189 files, +6336/-2571 |

### 📝 Recent Commits

- [`71bb2de8`](https://github.com/imputnet/cobalt/commit/71bb2de8) web/package: bump version to 11.0
- [`181669f9`](https://github.com/imputnet/cobalt/commit/181669f9) api/package: bump version to 11.0
- [`2df36735`](https://github.com/imputnet/cobalt/commit/2df36735) web/changelogs: add 11.0 changelog
- [`11520ccd`](https://github.com/imputnet/cobalt/commit/11520ccd) web/README: update for cobalt 11, add acknowledgments
- [`3c415851`](https://github.com/imputnet/cobalt/commit/3c415851) api/schema: add old variables from cobalt 10 for backwards compatibility
- [`1a712db9`](https://github.com/imputnet/cobalt/commit/1a712db9) web/css: add <code> styling
- [`f9a3fb13`](https://github.com/imputnet/cobalt/commit/f9a3fb13) web/layout: add a rounded corner & top border when installed on desktop
- [`d4a2fe50`](https://github.com/imputnet/cobalt/commit/d4a2fe50) web: add support for "remux" type of local processing
- [`bc8dcd5a`](https://github.com/imputnet/cobalt/commit/bc8dcd5a) web/ProcessingQueueItem: show running text even if there's no percentage
- [`50a0f29e`](https://github.com/imputnet/cobalt/commit/50a0f29e) docs/api: rewrite with up-to-date info and better formatting

[🔗 View full comparison](https://github.com/imputnet/cobalt/compare/6fbc585...71bb2de)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
