### PR TITLE
chore(apps/cobalt): update version to 11.0.1

### DIFF
--- a/apps/cobalt/Dockerfile
+++ b/apps/cobalt/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone https://github.com/imputnet/cobalt.git . && git checkout 71bb2de
+RUN git clone https://github.com/imputnet/cobalt.git . && git checkout 5c1a855
 
 FROM node:23-alpine AS builder
 WORKDIR /app

--- a/apps/cobalt/meta.json
+++ b/apps/cobalt/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "cobalt",
-  "version": "11.0",
+  "version": "11.0.1",
   "repo": "https://github.com/imputnet/cobalt",
-  "sha": "71bb2de81a977f3ffabe02d55934ab476ffda425",
+  "sha": "5c1a855ddf4f682c54e33207af9e9e4b2a6fdec6",
   "checkVer": {
     "type": "version",
     "file": "web/package.json",
@@ -19,8 +19,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=11.0",
-      "type=raw,value=71bb2de"
+      "type=raw,value=11.0.1",
+      "type=raw,value=5c1a855"
     ],
     "labels": {
       "title": "Cobalt",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update cobalt version to `11.0.1`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [cobalt](https://github.com/imputnet/cobalt) |
| **Version** | `11.0` → `11.0.1` |
| **Revision** | [`71bb2de`](https://github.com/imputnet/cobalt/commit/71bb2de81a977f3ffabe02d55934ab476ffda425) → [`5c1a855`](https://github.com/imputnet/cobalt/commit/5c1a855ddf4f682c54e33207af9e9e4b2a6fdec6) |
| **Latest Commit** | web/package: update version to 11.0.1 |
| **Author** | wukko <me@wukko.me> |
| **Date** | 2025-06-03 14:25:28 |
| **Changes** | 23 files, +172/-86 |

### 📝 Recent Commits

- [`5c1a855d`](https://github.com/imputnet/cobalt/commit/5c1a855d) web/package: update version to 11.0.1
- [`c2ff7afc`](https://github.com/imputnet/cobalt/commit/c2ff7afc) web/about/privacy: add a link to plausible host &amp; update cf section
- [`b304549a`](https://github.com/imputnet/cobalt/commit/b304549a) web/routes: refactor error &amp; /about/[page] to svelte 5
- [`58209970`](https://github.com/imputnet/cobalt/commit/58209970) web/wrangler: add not_found_handling
- [`ee2be1fb`](https://github.com/imputnet/cobalt/commit/ee2be1fb) web/device: enable local processing on ios 18+ by default
- [`3ee7c4d3`](https://github.com/imputnet/cobalt/commit/3ee7c4d3) web: add cloudflare wrangler.jsonc file
- [`b4a53d0f`](https://github.com/imputnet/cobalt/commit/b4a53d0f) web/state/task-manager: use writable-readonly store instead of readable
- [`7f5a9cfa`](https://github.com/imputnet/cobalt/commit/7f5a9cfa) api/config: remove unused cluster import
- [`a7bf5c52`](https://github.com/imputnet/cobalt/commit/a7bf5c52) api/package: bump version to 11.0.2
- [`57eba519`](https://github.com/imputnet/cobalt/commit/57eba519) api/env: broadcast raw contents instead of parsed

[🔗 View full comparison](https://github.com/imputnet/cobalt/compare/71bb2de...5c1a855)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
