### PR TITLE
chore(apps/cobalt): update version to 11.2

### DIFF
--- a/apps/cobalt/Dockerfile
+++ b/apps/cobalt/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone https://github.com/imputnet/cobalt.git . && git checkout 5ac87ba
+RUN git clone https://github.com/imputnet/cobalt.git . && git checkout a60e94d
 
 FROM node:23-alpine AS builder
 WORKDIR /app

--- a/apps/cobalt/meta.json
+++ b/apps/cobalt/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "cobalt",
-  "version": "11.0.2",
+  "version": "11.2",
   "repo": "https://github.com/imputnet/cobalt",
-  "sha": "5ac87bab093f735d079b7af40d09b4b7b0ad9d33",
+  "sha": "a60e94d6288f5a21fa8420348c0bad97594b760a",
   "checkVer": {
     "type": "version",
     "file": "web/package.json",
@@ -19,8 +19,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=11.0.2",
-      "type=raw,value=5ac87ba"
+      "type=raw,value=11.2",
+      "type=raw,value=a60e94d"
     ],
     "labels": {
       "title": "Cobalt",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update cobalt version to `11.2`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [cobalt](https://github.com/imputnet/cobalt) |
| **Version** | `11.0.2` → `11.2` |
| **Revision** | [`5ac87ba`](https://github.com/imputnet/cobalt/commit/5ac87bab093f735d079b7af40d09b4b7b0ad9d33) → [`a60e94d`](https://github.com/imputnet/cobalt/commit/a60e94d6288f5a21fa8420348c0bad97594b760a) |
| **Latest Commit** | web/package: bump version to 11.2 |
| **Author** | wukko <me@wukko.me> |
| **Date** | 2025-06-28 22:47:14 |
| **Changes** | 79 files, +1411/-793 |

### 📝 Recent Commits

- [`a60e94d6`](https://github.com/imputnet/cobalt/commit/a60e94d6) web/package: bump version to 11.2
- [`8da71e41`](https://github.com/imputnet/cobalt/commit/8da71e41) api/package: bump version to 11.2
- [`a751f81e`](https://github.com/imputnet/cobalt/commit/a751f81e) version-info: return git branch info correctly in cf workers
- [`bd0caac5`](https://github.com/imputnet/cobalt/commit/bd0caac5) web/changelogs/11.0: set a fixed commit in compare, fix env name error
- [`4fc2952c`](https://github.com/imputnet/cobalt/commit/4fc2952c) web/audio-sub-language: update localized values dynamically
- [`d70180b2`](https://github.com/imputnet/cobalt/commit/d70180b2) api/core: merge isApiKey and isSession into authType
- [`bc8c16f4`](https://github.com/imputnet/cobalt/commit/bc8c16f4) web/env: accept 1 as bool value
- [`3d2473d8`](https://github.com/imputnet/cobalt/commit/3d2473d8) web/audio-sub-language: refactor to avoid code duplication
- [`c1644412`](https://github.com/imputnet/cobalt/commit/c1644412) api/env: backwards compatibility with SESSION_RATELIMIT
- [`7298082b`](https://github.com/imputnet/cobalt/commit/7298082b) api: refactor two static arrays to set

[🔗 View full comparison](https://github.com/imputnet/cobalt/compare/5ac87ba...a60e94d)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
