### PR TITLE
chore(apps/cobalt): update version to 11.2.3

### DIFF
--- a/apps/cobalt/Dockerfile
+++ b/apps/cobalt/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone https://github.com/imputnet/cobalt.git . && git checkout 4d2c8b0
+RUN git clone https://github.com/imputnet/cobalt.git . && git checkout 773ed02
 
 FROM node:23-alpine AS builder
 WORKDIR /app

--- a/apps/cobalt/meta.json
+++ b/apps/cobalt/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "cobalt",
-  "version": "11.2.2",
+  "version": "11.2.3",
   "repo": "https://github.com/imputnet/cobalt",
-  "sha": "4d2c8b0a8c78a70cd6ffc6cf10540e9115baa093",
+  "sha": "773ed026b87182d1071652be86a4f964cba1d967",
   "checkVer": {
     "type": "version",
     "file": "web/package.json",
@@ -19,8 +19,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=11.2.2",
-      "type=raw,value=4d2c8b0"
+      "type=raw,value=11.2.3",
+      "type=raw,value=773ed02"
     ],
     "labels": {
       "title": "Cobalt",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update cobalt version to `11.2.3`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [cobalt](https://github.com/imputnet/cobalt) |
| **Version** | `11.2.2` → `11.2.3` |
| **Revision** | [`4d2c8b0`](https://github.com/imputnet/cobalt/commit/4d2c8b0a8c78a70cd6ffc6cf10540e9115baa093) → [`773ed02`](https://github.com/imputnet/cobalt/commit/773ed026b87182d1071652be86a4f964cba1d967) |
| **Latest Commit** | web/package: bump version to 11.2.3 |
| **Author** | wukko <me@wukko.me> |
| **Date** | 2025-07-04 15:57:17 |
| **Changes** | 11 files, +43/-27 |

### 📝 Recent Commits

- [`773ed026`](https://github.com/imputnet/cobalt/commit/773ed026) web/package: bump version to 11.2.3
- [`926e9b72`](https://github.com/imputnet/cobalt/commit/926e9b72) api/package: bump version to 11.2.1
- [`23064f83`](https://github.com/imputnet/cobalt/commit/23064f83) web/changelogs/11.2: add info about youtube&#39;s unavailability
- [`f3992fbe`](https://github.com/imputnet/cobalt/commit/f3992fbe) api/language-codes: prevent errors if code is undefined
- [`810e0a86`](https://github.com/imputnet/cobalt/commit/810e0a86) api/package: replace youtubei.js with a fork, update undici
- [`5b12622b`](https://github.com/imputnet/cobalt/commit/5b12622b) web/FilenamePreview: fix unlocalized strings
- [`9b3ebe90`](https://github.com/imputnet/cobalt/commit/9b3ebe90) api/language-codes: remove region part of the language code

[🔗 View full comparison](https://github.com/imputnet/cobalt/compare/4d2c8b0...773ed02)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
