### PR TITLE
chore(apps/cobalt): update version to 11.2.4

### DIFF
--- a/apps/cobalt/Dockerfile
+++ b/apps/cobalt/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone https://github.com/imputnet/cobalt.git . && git checkout 773ed02
+RUN git clone https://github.com/imputnet/cobalt.git . && git checkout 8353bd2
 
 FROM node:23-alpine AS builder
 WORKDIR /app

--- a/apps/cobalt/meta.json
+++ b/apps/cobalt/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "cobalt",
-  "version": "11.2.3",
+  "version": "11.2.4",
   "repo": "https://github.com/imputnet/cobalt",
-  "sha": "773ed026b87182d1071652be86a4f964cba1d967",
+  "sha": "8353bd20752269bff17d264f3f7377d2906c720a",
   "checkVer": {
     "type": "version",
     "file": "web/package.json",
@@ -19,8 +19,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=11.2.3",
-      "type=raw,value=773ed02"
+      "type=raw,value=11.2.4",
+      "type=raw,value=8353bd2"
     ],
     "labels": {
       "title": "Cobalt",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update cobalt version to `11.2.4`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [cobalt](https://github.com/imputnet/cobalt) |
| **Version** | `11.2.3` → `11.2.4` |
| **Revision** | [`773ed02`](https://github.com/imputnet/cobalt/commit/773ed026b87182d1071652be86a4f964cba1d967) → [`8353bd2`](https://github.com/imputnet/cobalt/commit/8353bd20752269bff17d264f3f7377d2906c720a) |
| **Latest Commit** | web/package: bump version to 11.2.4 |
| **Author** | wukko <me@wukko.me> |
| **Date** | 2025-07-09 18:14:03 |
| **Changes** | 13 files, +87/-19 |

### 📝 Recent Commits

- [`8353bd20`](https://github.com/imputnet/cobalt/commit/8353bd20) web/package: bump version to 11.2.4
- [`1a499238`](https://github.com/imputnet/cobalt/commit/1a499238) api/package: bump version to 11.2.3
- [`58ea4aed`](https://github.com/imputnet/cobalt/commit/58ea4aed) api/soundcloud: check if a cover url returns 200
- [`e8113a83`](https://github.com/imputnet/cobalt/commit/e8113a83) web/changelog/11.2: add info about vk download speed
- [`94a8eab5`](https://github.com/imputnet/cobalt/commit/94a8eab5) web/i18n/save: rephrase the disclaimer to cover our ass more
- [`51a9680b`](https://github.com/imputnet/cobalt/commit/51a9680b) api/match: fix localDisabled
- [`40da8a46`](https://github.com/imputnet/cobalt/commit/40da8a46) api/config: update chromium version in generic user agent
- [`2e86a6ca`](https://github.com/imputnet/cobalt/commit/2e86a6ca) api/bilibili: don&#39;t return isHLS
- [`43f47934`](https://github.com/imputnet/cobalt/commit/43f47934) web/i18n/ru: rephrase some strings
- [`2ac0436f`](https://github.com/imputnet/cobalt/commit/2ac0436f) api/tiktok: return empty error if there&#39;s nothing to download

[🔗 View full comparison](https://github.com/imputnet/cobalt/compare/773ed02...8353bd2)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
