### PR TITLE
chore(apps/memogram): update version to 0.2.1

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone --branch v0.2.0 https://github.com/usememos/telegram-integration.git .
+RUN git clone --branch v0.2.1 https://github.com/usememos/telegram-integration.git .
 
 # Build stage
 FROM cgr.dev/chainguard/go:latest AS builder

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "memogram",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repo": "https://github.com/usememos/telegram-integration",
-  "sha": "99e8b304ac788a071eea636068a9bab50f7b830f",
+  "sha": "5121142b0d65dbc9706f476e0365607b4281e3c8",
   "checkVer": {
     "type": "tag",
     "targetVersion": "v0.2.1"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.2.0",
-      "type=raw,value=99e8b30"
+      "type=raw,value=0.2.1",
+      "type=raw,value=5121142"
     ],
     "labels": {
       "title": "Memogram",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update memogram version to `0.2.1`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telegram-integration](https://github.com/usememos/telegram-integration) |
| **Version** | `0.2.0` → `0.2.1` |
| **Revision** | [`99e8b30`](https://github.com/usememos/telegram-integration/commit/99e8b304ac788a071eea636068a9bab50f7b830f) → [`5121142`](https://github.com/usememos/telegram-integration/commit/5121142b0d65dbc9706f476e0365607b4281e3c8) |
| **Latest Commit** | fix: search filter |
| **Author** | johnnyjoy <yourselfhosted@gmail.com> |
| **Date** | 2025-02-06 19:30:29 |
| **Changes** | 4 files, +25/-29 |

### 📝 Recent Commits

- [`5121142`](https://github.com/usememos/telegram-integration/commit/5121142) fix: search filter
- [`ae7c760`](https://github.com/usememos/telegram-integration/commit/ae7c760) chore: bump google.golang.org/protobuf from 1.36.2 to 1.36.4 (#103)
- [`ccdd223`](https://github.com/usememos/telegram-integration/commit/ccdd223) chore: bump google.golang.org/grpc from 1.69.2 to 1.70.0 (#102)
- [`22f735f`](https://github.com/usememos/telegram-integration/commit/22f735f) chore: bump actions/stale from 9.0.0 to 9.1.0 (#101)

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/99e8b30...5121142)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
