### PR TITLE
chore(apps/memogram): update version to 0.2.2

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone --branch v0.2.1 https://github.com/usememos/telegram-integration.git .
+RUN git clone --branch v0.2.2 https://github.com/usememos/telegram-integration.git .
 
 # Build stage
 FROM cgr.dev/chainguard/go:latest AS builder

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "memogram",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repo": "https://github.com/usememos/telegram-integration",
-  "sha": "5121142b0d65dbc9706f476e0365607b4281e3c8",
+  "sha": "e66929c889f1985bc4d36a14e5104baa72fdbb92",
   "checkVer": {
     "type": "tag",
     "targetVersion": "v0.2.2"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.2.1",
-      "type=raw,value=5121142"
+      "type=raw,value=0.2.2",
+      "type=raw,value=e66929c"
     ],
     "labels": {
       "title": "Memogram",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update memogram version to `0.2.2`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telegram-integration](https://github.com/usememos/telegram-integration) |
| **Version** | `0.2.1` → `0.2.2` |
| **Revision** | [`5121142`](https://github.com/usememos/telegram-integration/commit/5121142b0d65dbc9706f476e0365607b4281e3c8) → [`e66929c`](https://github.com/usememos/telegram-integration/commit/e66929c889f1985bc4d36a14e5104baa72fdbb92) |
| **Latest Commit** | fix: content search |
| **Author** | Johnny <yourselfhosted@gmail.com> |
| **Date** | 2025-02-07 13:02:28 |
| **Changes** | 1 files, +1/-1 |

### 📝 Recent Commits

- [`e66929c`](https://github.com/usememos/telegram-integration/commit/e66929c) fix: content search

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/5121142...e66929c)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
