### PR TITLE
chore(apps/memogram): update version to 0.2.3

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone --branch v0.2.2 https://github.com/usememos/telegram-integration.git .
+RUN git clone --branch v0.2.3 https://github.com/usememos/telegram-integration.git .
 
 # Build stage
 FROM cgr.dev/chainguard/go:latest AS builder

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "memogram",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "repo": "https://github.com/usememos/telegram-integration",
-  "sha": "e66929c889f1985bc4d36a14e5104baa72fdbb92",
+  "sha": "96e460c07a7b791ad321e9bdd17326e6fc1febcb",
   "checkVer": {
     "type": "tag",
     "targetVersion": "v0.2.3"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.2.2",
-      "type=raw,value=e66929c"
+      "type=raw,value=0.2.3",
+      "type=raw,value=96e460c"
     ],
     "labels": {
       "title": "Memogram",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update memogram version to `0.2.3`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telegram-integration](https://github.com/usememos/telegram-integration) |
| **Version** | `0.2.2` → `0.2.3` |
| **Revision** | [`e66929c`](https://github.com/usememos/telegram-integration/commit/e66929c889f1985bc4d36a14e5104baa72fdbb92) → [`96e460c`](https://github.com/usememos/telegram-integration/commit/96e460c07a7b791ad321e9bdd17326e6fc1febcb) |
| **Latest Commit** | fix: search |
| **Author** | Steven <stevenlgtm@gmail.com> |
| **Date** | 2025-02-17 22:33:35 |
| **Changes** | 6 files, +48/-24 |

### 📝 Recent Commits

- [`96e460c`](https://github.com/usememos/telegram-integration/commit/96e460c) fix: search
- [`32b0959`](https://github.com/usememos/telegram-integration/commit/32b0959) chore: bump github.com/go-telegram/bot from 1.13.3 to 1.14.0 (#110)
- [`fc733bb`](https://github.com/usememos/telegram-integration/commit/fc733bb) chore: bump google.golang.org/protobuf from 1.36.4 to 1.36.5 (#109)

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/e66929c...96e460c)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
