### PR TITLE
chore(apps/memogram): update version to 0.2.4

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone --branch v0.2.3 https://github.com/usememos/telegram-integration.git .
+RUN git clone --branch v0.2.4 https://github.com/usememos/telegram-integration.git .
 
 # Build stage
 FROM cgr.dev/chainguard/go:latest AS builder

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "memogram",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "repo": "https://github.com/usememos/telegram-integration",
-  "sha": "96e460c07a7b791ad321e9bdd17326e6fc1febcb",
+  "sha": "3a600a458461527fd096acaeb776f8940be56e33",
   "checkVer": {
     "type": "tag",
     "targetVersion": "v0.2.4"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.2.3",
-      "type=raw,value=96e460c"
+      "type=raw,value=0.2.4",
+      "type=raw,value=3a600a4"
     ],
     "labels": {
       "title": "Memogram",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update memogram version to `0.2.4`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telegram-integration](https://github.com/usememos/telegram-integration) |
| **Version** | `0.2.3` → `0.2.4` |
| **Revision** | [`96e460c`](https://github.com/usememos/telegram-integration/commit/96e460c07a7b791ad321e9bdd17326e6fc1febcb) → [`3a600a4`](https://github.com/usememos/telegram-integration/commit/3a600a458461527fd096acaeb776f8940be56e33) |
| **Latest Commit** | fix: media group mutex |
| **Author** | Steven <stevenlgtm@gmail.com> |
| **Date** | 2025-02-17 23:04:22 |
| **Changes** | 2 files, +14/-81 |

### 📝 Recent Commits

- [`3a600a4`](https://github.com/usememos/telegram-integration/commit/3a600a4) fix: media group mutex

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/96e460c...3a600a4)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
