### PR TITLE
chore(apps/memogram): update version to 0.2.5

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone --branch v0.2.4 https://github.com/usememos/telegram-integration.git .
+RUN git clone --branch v0.2.5 https://github.com/usememos/telegram-integration.git .
 
 # Build stage
 FROM cgr.dev/chainguard/go:latest AS builder

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "memogram",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "repo": "https://github.com/usememos/telegram-integration",
-  "sha": "3a600a458461527fd096acaeb776f8940be56e33",
+  "sha": "baa899b6e0c2baddd2316318cdd1d8d7c4aefcda",
   "checkVer": {
     "type": "tag",
     "targetVersion": "v0.2.5"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.2.4",
-      "type=raw,value=3a600a4"
+      "type=raw,value=0.2.5",
+      "type=raw,value=baa899b"
     ],
     "labels": {
       "title": "Memogram",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update memogram version to `0.2.5`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telegram-integration](https://github.com/usememos/telegram-integration) |
| **Version** | `0.2.4` → `0.2.5` |
| **Revision** | [`3a600a4`](https://github.com/usememos/telegram-integration/commit/3a600a458461527fd096acaeb776f8940be56e33) → [`baa899b`](https://github.com/usememos/telegram-integration/commit/baa899b6e0c2baddd2316318cdd1d8d7c4aefcda) |
| **Latest Commit** | feat: limit bot usage by specified usernames and support absolute path to data file path (#126) |
| **Author** | Alexander Kutsan <alexkutsan@gmail.com> |
| **Date** | 2025-06-03 21:27:33 |
| **Changes** | 5 files, +143/-46 |

### 📝 Recent Commits

- [`baa899b`](https://github.com/usememos/telegram-integration/commit/baa899b) feat: limit bot usage by specified usernames and support absolute path to data file path (#126)
- [`339cffa`](https://github.com/usememos/telegram-integration/commit/339cffa) chore: bump github.com/usememos/memos from 0.24.2 to 0.24.4 (#132)
- [`4988be3`](https://github.com/usememos/telegram-integration/commit/4988be3) chore: bump golang.org/x/net from 0.35.0 to 0.38.0 (#127)
- [`2b99150`](https://github.com/usememos/telegram-integration/commit/2b99150) chore: bump github.com/go-telegram/bot from 1.14.2 to 1.15.0 (#125)
- [`c497a6c`](https://github.com/usememos/telegram-integration/commit/c497a6c) chore: bump github.com/go-telegram/bot from 1.14.1 to 1.14.2 (#122)
- [`62b1eb3`](https://github.com/usememos/telegram-integration/commit/62b1eb3) chore: bump google.golang.org/grpc from 1.71.1 to 1.72.0 (#123)
- [`e7e1e6f`](https://github.com/usememos/telegram-integration/commit/e7e1e6f) chore: bump google.golang.org/grpc from 1.70.0 to 1.71.1 (#121)
- [`a6051a4`](https://github.com/usememos/telegram-integration/commit/a6051a4) chore: bump google.golang.org/protobuf from 1.36.5 to 1.36.6 (#117)
- [`dfadcc4`](https://github.com/usememos/telegram-integration/commit/dfadcc4) chore: bump github.com/go-telegram/bot from 1.14.0 to 1.14.1 (#116)
- [`fa27beb`](https://github.com/usememos/telegram-integration/commit/fa27beb) chore: bump github.com/usememos/memos from 0.24.0 to 0.24.2 (#118)

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/3a600a4...baa899b)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
