### PR TITLE
chore(apps/memogram): update version to 0.2.6

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone --branch v0.2.5 https://github.com/usememos/telegram-integration.git .
+RUN git clone --branch v0.2.6 https://github.com/usememos/telegram-integration.git .
 
 # Build stage
 FROM cgr.dev/chainguard/go:latest AS builder

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "memogram",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "repo": "https://github.com/usememos/telegram-integration",
-  "sha": "baa899b6e0c2baddd2316318cdd1d8d7c4aefcda",
+  "sha": "7629446c396a1fd1639f4675d9bd3ae8c7207a0a",
   "checkVer": {
     "type": "tag",
     "targetVersion": "v0.2.6"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.2.5",
-      "type=raw,value=baa899b"
+      "type=raw,value=0.2.6",
+      "type=raw,value=7629446"
     ],
     "labels": {
       "title": "Memogram",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update memogram version to `0.2.6`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telegram-integration](https://github.com/usememos/telegram-integration) |
| **Version** | `0.2.5` → `0.2.6` |
| **Revision** | [`baa899b`](https://github.com/usememos/telegram-integration/commit/baa899b6e0c2baddd2316318cdd1d8d7c4aefcda) → [`7629446`](https://github.com/usememos/telegram-integration/commit/7629446c396a1fd1639f4675d9bd3ae8c7207a0a) |
| **Latest Commit** | fix: npe from getConfigFromEnv |
| **Author** | Steven <stevenlgtm@gmail.com> |
| **Date** | 2025-06-23 23:30:50 |
| **Changes** | 4 files, +32/-25 |

### 📝 Recent Commits

- [`7629446`](https://github.com/usememos/telegram-integration/commit/7629446) fix: npe from getConfigFromEnv
- [`607cb87`](https://github.com/usememos/telegram-integration/commit/607cb87) chore: bump google.golang.org/grpc from 1.72.2 to 1.73.0 (#134)

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/baa899b...7629446)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
