### PR TITLE
chore(apps/memogram): update version to 0.3.0

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone --branch v0.2.6 https://github.com/usememos/telegram-integration.git .
+RUN git clone --branch v0.3.0 https://github.com/usememos/telegram-integration.git .
 
 # Build stage
 FROM cgr.dev/chainguard/go:latest AS builder

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "memogram",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "repo": "https://github.com/usememos/telegram-integration",
-  "sha": "7629446c396a1fd1639f4675d9bd3ae8c7207a0a",
+  "sha": "316ea40c31bd83e7acdaafd80507e8e4e086f686",
   "checkVer": {
     "type": "tag",
     "targetVersion": "v0.3.0"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.2.6",
-      "type=raw,value=7629446"
+      "type=raw,value=0.3.0",
+      "type=raw,value=316ea40"
     ],
     "labels": {
       "title": "Memogram",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update memogram version to `0.3.0`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telegram-integration](https://github.com/usememos/telegram-integration) |
| **Version** | `0.2.6` → `0.3.0` |
| **Revision** | [`7629446`](https://github.com/usememos/telegram-integration/commit/7629446c396a1fd1639f4675d9bd3ae8c7207a0a) → [`316ea40`](https://github.com/usememos/telegram-integration/commit/316ea40c31bd83e7acdaafd80507e8e4e086f686) |
| **Latest Commit** | chore: upgrade |
| **Author** | Steven <stevenlgtm@gmail.com> |
| **Date** | 2025-07-17 22:51:57 |
| **Changes** | 4 files, +64/-64 |

### 📝 Recent Commits

- [`316ea40`](https://github.com/usememos/telegram-integration/commit/316ea40) chore: upgrade
- [`29e2e03`](https://github.com/usememos/telegram-integration/commit/29e2e03) chore: bump github.com/go-telegram/bot from 1.15.0 to 1.16.0 (#135)

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/7629446...316ea40)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
