### PR TITLE
chore(apps/readest): update version to 0.9.66

### DIFF
--- a/apps/readest/Dockerfile
+++ b/apps/readest/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-RUN git clone -b v0.0.0 --recurse-submodules https://github.com/readest/readest .
+RUN git clone -b v0.9.66 --recurse-submodules https://github.com/readest/readest .
 
 FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"

--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "readest",
-  "version": "0.0.0",
+  "version": "0.9.66",
   "repo": "https://github.com/readest/readest",
-  "sha": "ac522b6",
+  "sha": "40058582422e2ce436d3233b326bfdf83ccedc5f",
   "checkVer": {
     "type": "version",
     "file": "apps/readest-app/package.json"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.0.0",
-      "type=raw,value=ac522b6"
+      "type=raw,value=0.9.66",
+      "type=raw,value=4005858"
     ],
     "labels": {
       "title": "Readest",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update readest version to `0.9.66`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [readest](https://github.com/readest/readest) |
| **Version** | `0.0.0` → `0.9.66` |
| **Revision** | [`ac522b6`](https://github.com/readest/readest/commit/ac522b6) → [`4005858`](https://github.com/readest/readest/commit/40058582422e2ce436d3233b326bfdf83ccedc5f) |
| **Latest Commit** | release: version 0.9.66 (#1643) |
| **Author** | Huang Xin <chrox.huang@gmail.com> |
| **Date** | 2025-07-21 05:12:40 |

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
