### PR TITLE
chore(apps/lsky-dev): update version to aa6dd04

### DIFF
--- a/apps/lsky-dev/Dockerfile
+++ b/apps/lsky-dev/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone https://github.com/lsky-org/lsky-pro.git . && git checkout aa9aa31
+RUN git clone https://github.com/lsky-org/lsky-pro.git . && git checkout aa6dd04
 
 FROM node:20-alpine3.20 AS web
 WORKDIR /app

--- a/apps/lsky-dev/meta.json
+++ b/apps/lsky-dev/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "lsky-dev",
-  "version": "aa9aa31",
+  "version": "aa6dd04",
   "repo": "https://github.com/lsky-org/lsky-pro",
-  "sha": "aa9aa31c42bfcc0b275c75070f7b72bbc1feb55c",
+  "sha": "aa6dd044ba668c647ffa40532a475a1e844c5e13",
   "checkVer": {
     "type": "sha"
   },
@@ -17,7 +17,7 @@
     "push": true,
     "tags": [
       "type=raw,value=dev",
-      "type=raw,value=aa9aa31-dev"
+      "type=raw,value=aa6dd04-dev"
     ],
     "labels": {
       "title": "兰空图床开发版",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update lsky-dev version to `aa6dd04`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [lsky-pro](https://github.com/lsky-org/lsky-pro) |
| **Version** | `aa9aa31` → `aa6dd04` |
| **Revision** | [`aa9aa31`](https://github.com/lsky-org/lsky-pro/commit/aa9aa31c42bfcc0b275c75070f7b72bbc1feb55c) → [`aa6dd04`](https://github.com/lsky-org/lsky-pro/commit/aa6dd044ba668c647ffa40532a475a1e844c5e13) |
| **Latest Commit** | Bump form-data from 4.0.1 to 4.0.4 (#870) |
| **Author** | dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com> |
| **Date** | 2025-07-23 08:25:56 |
| **Changes** | 1 files, +37/-6 |

### 📝 Recent Commits

- [`aa6dd044`](https://github.com/lsky-org/lsky-pro/commit/aa6dd044) Bump form-data from 4.0.1 to 4.0.4 (#870)

[🔗 View full comparison](https://github.com/lsky-org/lsky-pro/compare/aa9aa31...aa6dd04)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
