### PR TITLE
chore(apps/readest): update version to 0.9.70

### DIFF
--- a/apps/readest/Dockerfile
+++ b/apps/readest/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-RUN git clone -b v0.9.69 --recurse-submodules https://github.com/readest/readest .
+RUN git clone -b v0.9.70 --recurse-submodules https://github.com/readest/readest .
 
 FROM node:22-slim AS base
 ENV PNPM_HOME="/pnpm"

--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "readest",
-  "version": "0.9.69",
+  "version": "0.9.70",
   "repo": "https://github.com/readest/readest",
-  "sha": "1ef126f820e4941cf3dd9c166f18cd6bc54c1f44",
+  "sha": "847d514441cbc14bc8609428888da30ca704a8c4",
   "checkVer": {
     "type": "version",
     "file": "apps/readest-app/package.json"
@@ -18,8 +18,8 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=0.9.69",
-      "type=raw,value=1ef126f"
+      "type=raw,value=0.9.70",
+      "type=raw,value=847d514"
     ],
     "labels": {
       "title": "Readest",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update readest version to `0.9.70`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [readest](https://github.com/readest/readest) |
| **Version** | `0.9.69` → `0.9.70` |
| **Revision** | [`1ef126f`](https://github.com/readest/readest/commit/1ef126f820e4941cf3dd9c166f18cd6bc54c1f44) → [`847d514`](https://github.com/readest/readest/commit/847d514441cbc14bc8609428888da30ca704a8c4) |
| **Latest Commit** | fix: NativeFile access for file URI when importing files on iOS, closes #1746 (#1747) |
| **Author** | Huang Xin <chrox.huang@gmail.com> |
| **Date** | 2025-08-06 00:48:42 |
| **Changes** | 41 files, +316/-139 |

### 📝 Recent Commits

- [`847d5144`](https://github.com/readest/readest/commit/847d5144) fix: NativeFile access for file URI when importing files on iOS, closes #1746 (#1747)
- [`b2a71da2`](https://github.com/readest/readest/commit/b2a71da2) fix: chunk of cache item now has enough space for read of MAX_CACHE_CHUNK_SIZE, closes #1392 (#1744)
- [`3e5e4d29`](https://github.com/readest/readest/commit/3e5e4d29) compat: detect book language from text for invalid language code in metadata (#1743)
- [`e3c05e76`](https://github.com/readest/readest/commit/e3c05e76) feat: add reset password button in user page (#1742)
- [`df9ca2d2`](https://github.com/readest/readest/commit/df9ca2d2) api: migrate usage stats from KV to db (#1739)
- [`1631ece2`](https://github.com/readest/readest/commit/1631ece2) docs: doc submodule update as dependencies
- [`2ae25f3b`](https://github.com/readest/readest/commit/2ae25f3b) translator: add more translator languages (#1738)
- [`511093a6`](https://github.com/readest/readest/commit/511093a6) tts: tts now works when language codes are mistakenly set with language names (#1737)

[🔗 View full comparison](https://github.com/readest/readest/compare/1ef126f...847d514)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
