### PR TITLE
chore(apps/telemirror): update version to 90c52b1

### DIFF
--- a/apps/telemirror/Dockerfile
+++ b/apps/telemirror/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS base
 WORKDIR /app
-RUN git clone https://github.com/khoben/telemirror.git . && git checkout 22b7121
+RUN git clone https://github.com/khoben/telemirror.git . && git checkout 90c52b1
 
 FROM python:3.11-slim-bullseye AS build
 

--- a/apps/telemirror/meta.json
+++ b/apps/telemirror/meta.json
@@ -1,8 +1,8 @@
 {
   "name": "telemirror",
-  "version": "22b7121",
+  "version": "90c52b1",
   "repo": "https://github.com/khoben/telemirror",
-  "sha": "22b7121320ad1a652dbcd3bf6014b0a2349e799a",
+  "sha": "90c52b145da6f5891c886206523ed2db3adcfc86",
   "push": true,
   "tags": "",
   "checkVer": {
@@ -19,7 +19,7 @@
     "push": true,
     "tags": [
       "type=raw,value=latest",
-      "type=raw,value=22b7121"
+      "type=raw,value=90c52b1"
     ],
     "labels": {
       "title": "Telemirror",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update telemirror version to `90c52b1`

### 📋 Basic Information

| Key   | Value |
|-------|-------|
| **Repository** | [telemirror](https://github.com/khoben/telemirror) |
| **Version** | `22b7121` → `90c52b1` |
| **Revision** | [`22b7121`](https://github.com/khoben/telemirror/commit/22b7121320ad1a652dbcd3bf6014b0a2349e799a) → [`90c52b1`](https://github.com/khoben/telemirror/commit/90c52b145da6f5891c886206523ed2db3adcfc86) |
| **Latest Commit** | Update dependencies |
| **Author** | khoben <extless@gmail.com> |
| **Date** | 2025-08-12 10:31:09 |
| **Changes** | 7 files, +72/-10 |

### 📝 Recent Commits

- [`90c52b1`](https://github.com/khoben/telemirror/commit/90c52b1) Update dependencies
- [`4f6ac8c`](https://github.com/khoben/telemirror/commit/4f6ac8c) Set `SYSTEM_VERSION`, `DEVICE_MODEL` and `APP_VERSION` via .env

[🔗 View full comparison](https://github.com/khoben/telemirror/compare/22b7121...90c52b1)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
