### PR TITLE
update(apps/weserv): update alpine version to dcb8d29

### DIFF
--- a/apps/weserv/Dockerfile.alpine
+++ b/apps/weserv/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION={{version}}
+ARG VERSION=dcb8d29
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 # Based on:

--- a/apps/weserv/meta.json
+++ b/apps/weserv/meta.json
@@ -21,6 +21,8 @@
       }
     },
     "alpine": {
+      "version": "dcb8d29",
+      "sha": "dcb8d2980b7785593374ff6f8db994dbb656b005",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `weserv` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `alpine` | [`weserv/images`](https://github.com/weserv/images) | `N/A` → `dcb8d29` | `N/A` → [`dcb8d29`](https://github.com/weserv/images/commit/dcb8d2980b7785593374ff6f8db994dbb656b005) |


### 🔍 Details

#### `alpine`

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.17.1 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2025-07-09T19:02:55+08:00Z |
| **Changed** | N/A |

📝 Recent Commits

- [`dcb8d29`](https://github.com/weserv/images/commit/dcb8d29) Bump GitHub Actions libvips to 8.17.1
- [`6c90239`](https://github.com/weserv/images/commit/6c90239) Update nginx to 1.29.0
- [`54ec5ed`](https://github.com/weserv/images/commit/54ec5ed) Update CHANGELOG.md
- [`bc71042`](https://github.com/weserv/images/commit/bc71042) Ensure compatibility with freenginx
- [`1b7a06b`](https://github.com/weserv/images/commit/1b7a06b) Cleanup include directives
- [`dd2e828`](https://github.com/weserv/images/commit/dd2e828) Bump GitHub Actions libvips to 8.17.0
- [`fb9fd46`](https://github.com/weserv/images/commit/fb9fd46) Update Rocky Linux base image to version 10
- [`974e12a`](https://github.com/weserv/images/commit/974e12a) Update Alpine base image to version 3.22
- [`b872c88`](https://github.com/weserv/images/commit/b872c88) Update nginx to 1.27.5
- [`25a7215`](https://github.com/weserv/images/commit/25a7215) Update third-party modules

[🔗 View full comparison](https://github.com/weserv/images/commits/dcb8d29)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
