### PR TITLE
update(apps/lsky): update dev version to 2b3f31a

### DIFF
--- a/apps/lsky/Dockerfile.dev
+++ b/apps/lsky/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG VERSION=aa6dd04
+ARG VERSION=2b3f31a
 RUN git clone https://github.com/lsky-org/lsky-pro.git . && git checkout ${VERSION}
 
 FROM node:20-alpine3.20 AS web

--- a/apps/lsky/meta.json
+++ b/apps/lsky/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "aa6dd04",
-      "sha": "aa6dd044ba668c647ffa40532a475a1e844c5e13",
+      "version": "2b3f31a",
+      "sha": "2b3f31a204a9ad950453921fff05c42df10517ba",
       "checkver": {
         "type": "sha",
         "repo": "https://github.com/lsky-org/lsky-pro"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `lsky` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`lsky-org/lsky-pro`](https://github.com/lsky-org/lsky-pro) | `aa6dd04` → `2b3f31a` | [`aa6dd04`](https://github.com/lsky-org/lsky-pro/commit/aa6dd044ba668c647ffa40532a475a1e844c5e13) → [`2b3f31a`](https://github.com/lsky-org/lsky-pro/commit/2b3f31a204a9ad950453921fff05c42df10517ba) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`lsky-org/lsky-pro`](https://github.com/lsky-org/lsky-pro) |
| **Latest Commit** | Bump cipher-base from 1.0.4 to 1.0.6 (#872) |
| **Author** | dependabot[bot] &lt;49699333+dependabot[bot]@users.noreply.github.com&gt; |
| **Date** | 2025-08-22T07:54:10+08:00Z |
| **Changed** | 1 files, +87/-20 |

📝 Recent Commits

- [`2b3f31a2`](https://github.com/lsky-org/lsky-pro/commit/2b3f31a2) Bump cipher-base from 1.0.4 to 1.0.6 (#872)
- [`94332ee5`](https://github.com/lsky-org/lsky-pro/commit/94332ee5) Bump sha.js from 2.4.11 to 2.4.12 (#873)

[🔗 View full comparison](https://github.com/lsky-org/lsky-pro/compare/aa6dd04...2b3f31a)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
