### PR TITLE
update(apps/readest): update latest version to 0.9.76

### DIFF
--- a/apps/readest/Dockerfile
+++ b/apps/readest/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG READEST_VERSION=v0.9.75
+ARG READEST_VERSION=v0.9.76
 RUN git clone -b ${READEST_VERSION} --recurse-submodules https://github.com/readest/readest .
 
 FROM node:22-slim AS base

--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,8 +7,8 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.9.75",
-      "sha": "e472d1cf1e5bdd2609bfcef9c50537040eaaad45",
+      "version": "0.9.76",
+      "sha": "f0c249bce2a77c27f777758d6ce7dc113dfe1581",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.9.75` → `0.9.76` | [`e472d1c`](https://github.com/readest/readest/commit/e472d1cf1e5bdd2609bfcef9c50537040eaaad45) → [`f0c249b`](https://github.com/readest/readest/commit/f0c249bce2a77c27f777758d6ce7dc113dfe1581) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.9.76 (#1932) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2025-08-30T12:19:01+08:00Z |
| **Changed** | 104 files, +1307/-976 |

📝 Recent Commits

- [`f0c249bc`](https://github.com/readest/readest/commit/f0c249bc) release: version 0.9.76 (#1932)
- [`e8a96fba`](https://github.com/readest/readest/commit/e8a96fba) compat: more compat with window insets on Android (#1931)
- [`92b01c40`](https://github.com/readest/readest/commit/92b01c40) layout: fix grouping modal not shown on Linux (#1930)
- [`6003eead`](https://github.com/readest/readest/commit/6003eead) compat: support more kosync server implementations, closes #1862 (#1929)
- [`856ed4d3`](https://github.com/readest/readest/commit/856ed4d3) ux: add splash screen for iOS and Android and reduce flash when opening books (#1926)
- [`267fe58a`](https://github.com/readest/readest/commit/267fe58a) fix: reduce screen flash with different background colors when app starts, closes #1915 (#1922)
- [`1b00d8c4`](https://github.com/readest/readest/commit/1b00d8c4) fix: support importing azw3 files on Android, closes #1920 (#1921)
- [`cb126613`](https://github.com/readest/readest/commit/cb126613) perf(sync): incremental sync of library books (#1917)
- [`515bfee2`](https://github.com/readest/readest/commit/515bfee2) fix(kosync): normalize xpointer to improve KOReader sync tolerance, closes #1857 (#1914)
- [`584f3511`](https://github.com/readest/readest/commit/584f3511) refactor(kosync): move kosync into reader sidebar menu and add manual pull/push trigger (#1912)

[🔗 View full comparison](https://github.com/readest/readest/compare/e472d1c...f0c249b)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
