### PR TITLE
update(apps/icones): update latest version to f65e6db

### DIFF
--- a/apps/icones/Dockerfile
+++ b/apps/icones/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG VERSION=4d40739
+ARG VERSION=f65e6db
 RUN git clone https://github.com/antfu-collective/icones . && git checkout ${VERSION}
 
 FROM node:22.14.0-alpine3.20 AS build

--- a/apps/icones/meta.json
+++ b/apps/icones/meta.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "4d40739",
-      "sha": "4d4073932ce98c79d4952083d344339bb939e4de",
+      "version": "f65e6db",
+      "sha": "f65e6dbb4c23141f0e76dc915b91b58d0217287b",
       "checkver": {
         "type": "sha",
         "repo": "https://github.com/antfu-collective/icones"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `icones` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`antfu-collective/icones`](https://github.com/antfu-collective/icones) | `4d40739` → `f65e6db` | [`4d40739`](https://github.com/antfu-collective/icones/commit/4d4073932ce98c79d4952083d344339bb939e4de) → [`f65e6db`](https://github.com/antfu-collective/icones/commit/f65e6dbb4c23141f0e76dc915b91b58d0217287b) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`antfu-collective/icones`](https://github.com/antfu-collective/icones) |
| **Latest Commit** | feat: add UnoCSS snap usage (#374) |
| **Author** | Chris &lt;hizyyv@gmail.com&gt; |
| **Date** | 2025-09-01T21:46:22+08:00Z |
| **Changed** | 1 files, +6/-0 |

📝 Recent Commits

- [`f65e6db`](https://github.com/antfu-collective/icones/commit/f65e6db) feat: add UnoCSS snap usage (#374)

[🔗 View full comparison](https://github.com/antfu-collective/icones/compare/4d40739...f65e6db)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
