### PR TITLE
update(apps/readest): update latest version to 0.9.78

### DIFF
--- a/apps/readest/Dockerfile
+++ b/apps/readest/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG READEST_VERSION=v0.9.76
+ARG READEST_VERSION=v0.9.78
 RUN git clone -b ${READEST_VERSION} --recurse-submodules https://github.com/readest/readest .
 
 FROM node:22-slim AS base

--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,8 +7,8 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.9.76",
-      "sha": "f0c249bce2a77c27f777758d6ce7dc113dfe1581",
+      "version": "0.9.78",
+      "sha": "cc3cc58de066341347045c5939d7360ae19c7ce0",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.9.76` → `0.9.78` | [`f0c249b`](https://github.com/readest/readest/commit/f0c249bce2a77c27f777758d6ce7dc113dfe1581) → [`cc3cc58`](https://github.com/readest/readest/commit/cc3cc58de066341347045c5939d7360ae19c7ce0) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.9.78 (#1975) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2025-09-06T16:50:18+08:00Z |
| **Changed** | 83 files, +3009/-430 |

📝 Recent Commits

- [`cc3cc58d`](https://github.com/readest/readest/commit/cc3cc58d) release: version 0.9.78 (#1975)
- [`80d60266`](https://github.com/readest/readest/commit/80d60266) settings: default to override background color in fixed layout documents (#1974)
- [`f06cdb58`](https://github.com/readest/readest/commit/f06cdb58) txt: nest chapters inside volumes when converting to epub (#1972)
- [`dfe68988`](https://github.com/readest/readest/commit/dfe68988) fix(kosync): use 1-based indices in xpointer, closes #1968 (#1973)
- [`d0264de3`](https://github.com/readest/readest/commit/d0264de3) compat: more accessible iframes for PDFs, closes #1136 (#1971)
- [`77c43039`](https://github.com/readest/readest/commit/77c43039) feat(pdf): support setting zoom level, zoom mode and spread mode for PDF (#1969)
- [`5724d2ee`](https://github.com/readest/readest/commit/5724d2ee) feat(tts): support going previous/next by sentence in bottom TTS bar, closes #1816 (#1967)
- [`64007b11`](https://github.com/readest/readest/commit/64007b11) txt: improve zh chapter extraction (#1966)
- [`50ee7bd8`](https://github.com/readest/readest/commit/50ee7bd8) doc: change badge colors for last commit and commit activity
- [`2bcbde4b`](https://github.com/readest/readest/commit/2bcbde4b) doc: fixed badge-language-coverage URL encoding

[🔗 View full comparison](https://github.com/readest/readest/compare/f0c249b...cc3cc58)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
