### PR TITLE
update(apps/n8n-workflows): update latest version to 578cbef

### DIFF
--- a/apps/n8n-workflows/Dockerfile
+++ b/apps/n8n-workflows/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG VERSION=07ddbb9
+ARG VERSION=578cbef
 RUN git clone https://github.com/Zie619/n8n-workflows . && git checkout ${VERSION}
 
 FROM python:3.9-slim AS base

--- a/apps/n8n-workflows/meta.json
+++ b/apps/n8n-workflows/meta.json
@@ -5,8 +5,8 @@
   "description": "all of the workflows of n8n i could find (also from the site itself)",
   "variants": {
     "latest": {
-      "version": "07ddbb9",
-      "sha": "07ddbb96cea303b49a3ef910c1b520ee551f8d36",
+      "version": "578cbef",
+      "sha": "578cbef8c5a7887f7b8026b25e77fb1553208842",
       "checkver": {
         "type": "sha",
         "repo": "Zie619/n8n-workflows"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `n8n-workflows` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`Zie619/n8n-workflows`](https://github.com/Zie619/n8n-workflows) | `07ddbb9` → `578cbef` | [`07ddbb9`](https://github.com/Zie619/n8n-workflows/commit/07ddbb96cea303b49a3ef910c1b520ee551f8d36) → [`578cbef`](https://github.com/Zie619/n8n-workflows/commit/578cbef8c5a7887f7b8026b25e77fb1553208842) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`Zie619/n8n-workflows`](https://github.com/Zie619/n8n-workflows) |
| **Latest Commit** | Merge pull request #92 from MahmoudRedaShaban/main |
| **Author** | Eliad Shahar &lt;54673680+Zie619@users.noreply.github.com&gt; |
| **Date** | 2025-09-08T00:00:38+08:00Z |
| **Changed** | 1 files, +1/-0 |

📝 Recent Commits

- [`578cbef`](https://github.com/Zie619/n8n-workflows/commit/578cbef) Merge pull request #92 from MahmoudRedaShaban/main
- [`0fffb0a`](https://github.com/Zie619/n8n-workflows/commit/0fffb0a) fix: handle UnicodeEncodeError when printing banner emoji on Windows

[🔗 View full comparison](https://github.com/Zie619/n8n-workflows/compare/07ddbb9...578cbef)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
