### PR TITLE
update(apps/icones): update latest version to e07e435

### DIFF
--- a/apps/icones/Dockerfile
+++ b/apps/icones/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG VERSION=f65e6db
+ARG VERSION=e07e435
 RUN git clone https://github.com/antfu-collective/icones . && git checkout ${VERSION}
 
 FROM node:22.14.0-alpine3.20 AS build

--- a/apps/icones/meta.json
+++ b/apps/icones/meta.json
@@ -7,8 +7,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "f65e6db",
-      "sha": "f65e6dbb4c23141f0e76dc915b91b58d0217287b",
+      "version": "e07e435",
+      "sha": "e07e435b53158f7cca37ebaa3b08bd96ed7611b4",
       "checkver": {
         "type": "sha",
         "repo": "https://github.com/antfu-collective/icones"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `icones` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`antfu-collective/icones`](https://github.com/antfu-collective/icones) | `f65e6db` → `e07e435` | [`f65e6db`](https://github.com/antfu-collective/icones/commit/f65e6dbb4c23141f0e76dc915b91b58d0217287b) → [`e07e435`](https://github.com/antfu-collective/icones/commit/e07e435b53158f7cca37ebaa3b08bd96ed7611b4) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`antfu-collective/icones`](https://github.com/antfu-collective/icones) |
| **Latest Commit** | perf: debounce search (#376) |
| **Author** | Chris &lt;hizyyv@gmail.com&gt; |
| **Date** | 2025-09-09T15:20:42+08:00Z |
| **Changed** | 6 files, +1502/-1421 |

📝 Recent Commits

- [`e07e435`](https://github.com/antfu-collective/icones/commit/e07e435) perf: debounce search (#376)
- [`053e71e`](https://github.com/antfu-collective/icones/commit/053e71e) chore: upgrade deps (#375)

[🔗 View full comparison](https://github.com/antfu-collective/icones/compare/f65e6db...e07e435)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
