### PR TITLE
update(base/vscode): update latest version to 1.104.0, update stable version to 1.104.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.103.2
+ARG VERSION=1.104.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.103.2
+ARG VERSION=1.104.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.103.2",
-      "sha": "6f17636121051a53c88d3e605c491d22af2ba755",
+      "version": "1.104.0",
+      "sha": "f220831ea2d946c0dcb0f3eaa480eb435a2c1260",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode"
@@ -19,8 +19,8 @@
       }
     },
     "stable": {
-      "version": "1.103.2",
-      "sha": "6f17636121051a53c88d3e605c491d22af2ba755",
+      "version": "1.104.0",
+      "sha": "f220831ea2d946c0dcb0f3eaa480eb435a2c1260",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.103.2` → `1.104.0` | [`6f17636`](https://github.com/microsoft/vscode/commit/6f17636121051a53c88d3e605c491d22af2ba755) → [`f220831`](https://github.com/microsoft/vscode/commit/f220831ea2d946c0dcb0f3eaa480eb435a2c1260) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.103.2` → `1.104.0` | [`6f17636`](https://github.com/microsoft/vscode/commit/6f17636121051a53c88d3e605c491d22af2ba755) → [`f220831`](https://github.com/microsoft/vscode/commit/f220831ea2d946c0dcb0f3eaa480eb435a2c1260) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Merge pull request #265934 from mjbvz/dev/mjbvz/port-d7cd41aecdab2e7523af97696b5fe71a7976320c |
| **Author** | Matt Bierner &lt;12821956+mjbvz@users.noreply.github.com&gt; |
| **Date** | 2025-09-10T06:02:15+08:00Z |
| **Changed** | 1347 files, +70347/-21452 |

📝 Recent Commits

- [`f220831ea2d`](https://github.com/microsoft/vscode/commit/f220831ea2d) Merge pull request #265934 from mjbvz/dev/mjbvz/port-d7cd41aecdab2e7523af97696b5fe71a7976320c
- [`0867eb2ea40`](https://github.com/microsoft/vscode/commit/0867eb2ea40) Fix images in release notes
- [`fc2573605f9`](https://github.com/microsoft/vscode/commit/fc2573605f9) Do toString on markdown content (#265818)
- [`f4af2e756cb`](https://github.com/microsoft/vscode/commit/f4af2e756cb) Small fix to chat sessions sentiment check (#265786)
- [`ee8cc4ba9e8`](https://github.com/microsoft/vscode/commit/ee8cc4ba9e8) match orgs from chat extension (#265751)
- [`d1d3e550adb`](https://github.com/microsoft/vscode/commit/d1d3e550adb) Input type attribute to chat model (#265702)
- [`502442926f5`](https://github.com/microsoft/vscode/commit/502442926f5) Handle when equals sign shows up in a parameter (#265737)
- [`a7cdefd6c6c`](https://github.com/microsoft/vscode/commit/a7cdefd6c6c) Add `/login/oauth` path part to the ghes supported authorization server (#265703) (#265728)
- [`67a0ecd8295`](https://github.com/microsoft/vscode/commit/67a0ecd8295) triggerCommandOnProviderChange: true to restore old behavior (#265638)
- [`30822f6b8c4`](https://github.com/microsoft/vscode/commit/30822f6b8c4) fix: inverted colors for window.border system mode (release/1.104) (#265636)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/6f17636...f220831)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Merge pull request #265934 from mjbvz/dev/mjbvz/port-d7cd41aecdab2e7523af97696b5fe71a7976320c |
| **Author** | Matt Bierner &lt;12821956+mjbvz@users.noreply.github.com&gt; |
| **Date** | 2025-09-10T06:02:15+08:00Z |
| **Changed** | 1347 files, +70347/-21452 |

📝 Recent Commits

- [`f220831ea2d`](https://github.com/microsoft/vscode/commit/f220831ea2d) Merge pull request #265934 from mjbvz/dev/mjbvz/port-d7cd41aecdab2e7523af97696b5fe71a7976320c
- [`0867eb2ea40`](https://github.com/microsoft/vscode/commit/0867eb2ea40) Fix images in release notes
- [`fc2573605f9`](https://github.com/microsoft/vscode/commit/fc2573605f9) Do toString on markdown content (#265818)
- [`f4af2e756cb`](https://github.com/microsoft/vscode/commit/f4af2e756cb) Small fix to chat sessions sentiment check (#265786)
- [`ee8cc4ba9e8`](https://github.com/microsoft/vscode/commit/ee8cc4ba9e8) match orgs from chat extension (#265751)
- [`d1d3e550adb`](https://github.com/microsoft/vscode/commit/d1d3e550adb) Input type attribute to chat model (#265702)
- [`502442926f5`](https://github.com/microsoft/vscode/commit/502442926f5) Handle when equals sign shows up in a parameter (#265737)
- [`a7cdefd6c6c`](https://github.com/microsoft/vscode/commit/a7cdefd6c6c) Add `/login/oauth` path part to the ghes supported authorization server (#265703) (#265728)
- [`67a0ecd8295`](https://github.com/microsoft/vscode/commit/67a0ecd8295) triggerCommandOnProviderChange: true to restore old behavior (#265638)
- [`30822f6b8c4`](https://github.com/microsoft/vscode/commit/30822f6b8c4) fix: inverted colors for window.border system mode (release/1.104) (#265636)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/6f17636...f220831)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
