### PR TITLE
update(apps/weserv): update latest version to 7dbda97, update alpine version to 7dbda97

### DIFF
--- a/apps/weserv/Dockerfile
+++ b/apps/weserv/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=dcb8d29
+ARG VERSION=7dbda97
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 FROM docker.io/rockylinux/rockylinux:10

--- a/apps/weserv/Dockerfile.alpine
+++ b/apps/weserv/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=dcb8d29
+ARG VERSION=7dbda97
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 # Based on:

--- a/apps/weserv/meta.json
+++ b/apps/weserv/meta.json
@@ -5,8 +5,8 @@
   "description": "weserv 是一个用于快速生成图像的 API",
   "variants": {
     "latest": {
-      "version": "dcb8d29",
-      "sha": "dcb8d2980b7785593374ff6f8db994dbb656b005",
+      "version": "7dbda97",
+      "sha": "7dbda97e4b120edc4f0da1d5f92e4c62e643a05e",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",
@@ -21,8 +21,8 @@
       }
     },
     "alpine": {
-      "version": "dcb8d29",
-      "sha": "dcb8d2980b7785593374ff6f8db994dbb656b005",
+      "version": "7dbda97",
+      "sha": "7dbda97e4b120edc4f0da1d5f92e4c62e643a05e",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `weserv` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`weserv/images`](https://github.com/weserv/images) | `dcb8d29` → `7dbda97` | [`dcb8d29`](https://github.com/weserv/images/commit/dcb8d2980b7785593374ff6f8db994dbb656b005) → [`7dbda97`](https://github.com/weserv/images/commit/7dbda97e4b120edc4f0da1d5f92e4c62e643a05e) |
| `alpine` | [`weserv/images`](https://github.com/weserv/images) | `dcb8d29` → `7dbda97` | [`dcb8d29`](https://github.com/weserv/images/commit/dcb8d2980b7785593374ff6f8db994dbb656b005) → [`7dbda97`](https://github.com/weserv/images/commit/7dbda97e4b120edc4f0da1d5f92e4c62e643a05e) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.17.2 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2025-09-14T23:58:07+08:00Z |
| **Changed** | 17 files, +99/-77 |

📝 Recent Commits

- [`7dbda97`](https://github.com/weserv/images/commit/7dbda97) Bump GitHub Actions libvips to 8.17.2
- [`c5f93aa`](https://github.com/weserv/images/commit/c5f93aa) CI: Upgrade `actions/checkout` to v5
- [`e000ce0`](https://github.com/weserv/images/commit/e000ce0) Update nginx to 1.29.1
- [`5efd830`](https://github.com/weserv/images/commit/5efd830) Update third-party modules
- [`931c020`](https://github.com/weserv/images/commit/931c020) Migrate to BSD 3-Clause licensed Valkey
- [`aaf222a`](https://github.com/weserv/images/commit/aaf222a) Revert &quot;Fix compatibility with CMake &lt; 3.12&quot;
- [`73fa785`](https://github.com/weserv/images/commit/73fa785) Ensure `&amp;trim` is effective when used without a value
- [`9ad2919`](https://github.com/weserv/images/commit/9ad2919) Add support for specifying the trim background color (#459)

[🔗 View full comparison](https://github.com/weserv/images/compare/dcb8d29...7dbda97)

</p></details>

<details><summary>alpine</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.17.2 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2025-09-14T23:58:07+08:00Z |
| **Changed** | 17 files, +99/-77 |

📝 Recent Commits

- [`7dbda97`](https://github.com/weserv/images/commit/7dbda97) Bump GitHub Actions libvips to 8.17.2
- [`c5f93aa`](https://github.com/weserv/images/commit/c5f93aa) CI: Upgrade `actions/checkout` to v5
- [`e000ce0`](https://github.com/weserv/images/commit/e000ce0) Update nginx to 1.29.1
- [`5efd830`](https://github.com/weserv/images/commit/5efd830) Update third-party modules
- [`931c020`](https://github.com/weserv/images/commit/931c020) Migrate to BSD 3-Clause licensed Valkey
- [`aaf222a`](https://github.com/weserv/images/commit/aaf222a) Revert &quot;Fix compatibility with CMake &lt; 3.12&quot;
- [`73fa785`](https://github.com/weserv/images/commit/73fa785) Ensure `&amp;trim` is effective when used without a value
- [`9ad2919`](https://github.com/weserv/images/commit/9ad2919) Add support for specifying the trim background color (#459)

[🔗 View full comparison](https://github.com/weserv/images/compare/dcb8d29...7dbda97)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
