### PR TITLE
update(base/vscode): update latest version to 1.104.1, update stable version to 1.104.1

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.104.0
+ARG VERSION=1.104.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.104.0
+ARG VERSION=1.104.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.104.0",
-      "sha": "f220831ea2d946c0dcb0f3eaa480eb435a2c1260",
+      "version": "1.104.1",
+      "sha": "0f0d87fa9e96c856c5212fc86db137ac0d783365",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode"
@@ -19,8 +19,8 @@
       }
     },
     "stable": {
-      "version": "1.104.0",
-      "sha": "f220831ea2d946c0dcb0f3eaa480eb435a2c1260",
+      "version": "1.104.1",
+      "sha": "0f0d87fa9e96c856c5212fc86db137ac0d783365",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.104.0` → `1.104.1` | [`f220831`](https://github.com/microsoft/vscode/commit/f220831ea2d946c0dcb0f3eaa480eb435a2c1260) → [`0f0d87f`](https://github.com/microsoft/vscode/commit/0f0d87fa9e96c856c5212fc86db137ac0d783365) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.104.0` → `1.104.1` | [`f220831`](https://github.com/microsoft/vscode/commit/f220831ea2d946c0dcb0f3eaa480eb435a2c1260) → [`0f0d87f`](https://github.com/microsoft/vscode/commit/0f0d87fa9e96c856c5212fc86db137ac0d783365) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | fix thinking header (#267293) |
| **Author** | Justin Chen &lt;54879025+justschen@users.noreply.github.com&gt; |
| **Date** | 2025-09-18T07:30:36+08:00Z |
| **Changed** | 11 files, +32/-23 |

📝 Recent Commits

- [`0f0d87fa9e9`](https://github.com/microsoft/vscode/commit/0f0d87fa9e9) fix thinking header (#267293)
- [`e790554ed4b`](https://github.com/microsoft/vscode/commit/e790554ed4b) chore: update build for electron@37.3.1 (release/1.104) (#267255)
- [`4fce356fc5e`](https://github.com/microsoft/vscode/commit/4fce356fc5e) Revert &quot;Remove redundant activation &amp; log extension service activation errors…&quot; (#267062)
- [`67b5b2f79cd`](https://github.com/microsoft/vscode/commit/67b5b2f79cd) Merge pull request #266239 from mjbvz/dev/mjbvz/release-notes-fix
- [`e35b84fc065`](https://github.com/microsoft/vscode/commit/e35b84fc065) Bump distro for candidate (#266967)
- [`db5b33c0976`](https://github.com/microsoft/vscode/commit/db5b33c0976) Chat: telemetry for `alreadyInstalled` chat install kind missing and provider is wrong (#266334) (#266337)
- [`932425d65f4`](https://github.com/microsoft/vscode/commit/932425d65f4) bump version (#266333)
- [`eb1f08ce7b1`](https://github.com/microsoft/vscode/commit/eb1f08ce7b1) Fix TOC in release notes

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/f220831...0f0d87f)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | fix thinking header (#267293) |
| **Author** | Justin Chen &lt;54879025+justschen@users.noreply.github.com&gt; |
| **Date** | 2025-09-18T07:30:36+08:00Z |
| **Changed** | 11 files, +32/-23 |

📝 Recent Commits

- [`0f0d87fa9e9`](https://github.com/microsoft/vscode/commit/0f0d87fa9e9) fix thinking header (#267293)
- [`e790554ed4b`](https://github.com/microsoft/vscode/commit/e790554ed4b) chore: update build for electron@37.3.1 (release/1.104) (#267255)
- [`4fce356fc5e`](https://github.com/microsoft/vscode/commit/4fce356fc5e) Revert &quot;Remove redundant activation &amp; log extension service activation errors…&quot; (#267062)
- [`67b5b2f79cd`](https://github.com/microsoft/vscode/commit/67b5b2f79cd) Merge pull request #266239 from mjbvz/dev/mjbvz/release-notes-fix
- [`e35b84fc065`](https://github.com/microsoft/vscode/commit/e35b84fc065) Bump distro for candidate (#266967)
- [`db5b33c0976`](https://github.com/microsoft/vscode/commit/db5b33c0976) Chat: telemetry for `alreadyInstalled` chat install kind missing and provider is wrong (#266334) (#266337)
- [`932425d65f4`](https://github.com/microsoft/vscode/commit/932425d65f4) bump version (#266333)
- [`eb1f08ce7b1`](https://github.com/microsoft/vscode/commit/eb1f08ce7b1) Fix TOC in release notes

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/f220831...0f0d87f)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
