### PR TITLE
update(apps/readest): update latest version to 0.9.80

### DIFF
--- a/apps/readest/Dockerfile
+++ b/apps/readest/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG READEST_VERSION=v0.9.78
+ARG READEST_VERSION=v0.9.80
 RUN git clone -b ${READEST_VERSION} --recurse-submodules https://github.com/readest/readest .
 
 FROM node:22-slim AS base

--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,8 +7,8 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.9.78",
-      "sha": "cc3cc58de066341347045c5939d7360ae19c7ce0",
+      "version": "0.9.80",
+      "sha": "1bc0eb3a4b992fc14b649b4cc16016477f067368",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.9.78` → `0.9.80` | [`cc3cc58`](https://github.com/readest/readest/commit/cc3cc58de066341347045c5939d7360ae19c7ce0) → [`1bc0eb3`](https://github.com/readest/readest/commit/1bc0eb3a4b992fc14b649b4cc16016477f067368) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.9.80 (#2067) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2025-09-19T00:45:12+08:00Z |
| **Changed** | 155 files, +3378/-1087 |

📝 Recent Commits

- [`1bc0eb3a`](https://github.com/readest/readest/commit/1bc0eb3a) release: version 0.9.80 (#2067)
- [`c0bf2d40`](https://github.com/readest/readest/commit/c0bf2d40) fix: jump to current item in virtualized TOC list, closes #2055 (#2066)
- [`e30a39f9`](https://github.com/readest/readest/commit/e30a39f9) fix(config): prevent occasional errors when saving progress and configs (#2065)
- [`9727e4e9`](https://github.com/readest/readest/commit/9727e4e9) fix(metadata): handle invalid language code and title when importing, closes #2056 and closes #2058 (#2064)
- [`3380912c`](https://github.com/readest/readest/commit/3380912c) feat(kosync): use metadata hash to aggregate different versions of the same book (#2063)
- [`91a5454b`](https://github.com/readest/readest/commit/91a5454b) feat(sync): aggregate books with metadata hash for progress and annotation sync (#2062)
- [`e0c5acf4`](https://github.com/readest/readest/commit/e0c5acf4) chore: check file status before deleting cloud files (#2053)
- [`7e062be0`](https://github.com/readest/readest/commit/7e062be0) doc: update accessibility support in README (#2051)
- [`b23876c2`](https://github.com/readest/readest/commit/b23876c2) a11y: support NVDA screen reader on Windows and Orca screen reader on Linux (#2050)
- [`e9a15268`](https://github.com/readest/readest/commit/e9a15268) fix(layout): show focus ring only for keyboard navigation (#2046)

[🔗 View full comparison](https://github.com/readest/readest/compare/cc3cc58...1bc0eb3)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
