### PR TITLE
update(apps/n8n-workflows): update latest version to 03609df

### DIFF
--- a/apps/n8n-workflows/Dockerfile
+++ b/apps/n8n-workflows/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG VERSION=f01937f
+ARG VERSION=03609df
 RUN git clone https://github.com/Zie619/n8n-workflows . && git checkout ${VERSION}
 
 FROM python:3.9-slim AS base

--- a/apps/n8n-workflows/meta.json
+++ b/apps/n8n-workflows/meta.json
@@ -5,8 +5,8 @@
   "description": "all of the workflows of n8n i could find (also from the site itself)",
   "variants": {
     "latest": {
-      "version": "f01937f",
-      "sha": "f01937f71e7d86e3c6c09d7939b37b80c24ae9c5",
+      "version": "03609df",
+      "sha": "03609dfca295f9dffa55dfb69ed6f82639a846b9",
       "checkver": {
         "type": "sha",
         "repo": "Zie619/n8n-workflows"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `n8n-workflows` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`Zie619/n8n-workflows`](https://github.com/Zie619/n8n-workflows) | `f01937f` → `03609df` | [`f01937f`](https://github.com/Zie619/n8n-workflows/commit/f01937f71e7d86e3c6c09d7939b37b80c24ae9c5) → [`03609df`](https://github.com/Zie619/n8n-workflows/commit/03609dfca295f9dffa55dfb69ed6f82639a846b9) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`Zie619/n8n-workflows`](https://github.com/Zie619/n8n-workflows) |
| **Latest Commit** | Merge pull request #113 from CalcsLive/fix-github-pages-deployment |
| **Author** | Eliad Shahar &lt;54673680+Zie619@users.noreply.github.com&gt; |
| **Date** | 2025-10-01T04:19:02+08:00Z |
| **Changed** | 1 files, +1/-0 |

📝 Recent Commits

- [`03609dfc`](https://github.com/Zie619/n8n-workflows/commit/03609dfc) Merge pull request #113 from CalcsLive/fix-github-pages-deployment
- [`34fae1cc`](https://github.com/Zie619/n8n-workflows/commit/34fae1cc) fix: Add timestamp to GitHub Pages footer to trigger deployment

[🔗 View full comparison](https://github.com/Zie619/n8n-workflows/compare/f01937f...03609df)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
