### PR TITLE
update(apps/readest): update latest version to 0.9.82

### DIFF
--- a/apps/readest/Dockerfile
+++ b/apps/readest/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG READEST_VERSION=v0.9.81
+ARG READEST_VERSION=v0.9.82
 RUN git clone -b ${READEST_VERSION} --recurse-submodules https://github.com/readest/readest .
 
 FROM node:22-slim AS base

--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,8 +7,8 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.9.81",
-      "sha": "519e2228833aa812190af15dd905e79777f0a40b",
+      "version": "0.9.82",
+      "sha": "e1691661d9a00a30864bbf3bfd0861e2496983fa",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.9.81` → `0.9.82` | [`519e222`](https://github.com/readest/readest/commit/519e2228833aa812190af15dd905e79777f0a40b) → [`e169166`](https://github.com/readest/readest/commit/e1691661d9a00a30864bbf3bfd0861e2496983fa) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.9.82 (#2155) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2025-10-01T22:45:01+08:00Z |
| **Changed** | 155 files, +4788/-1414 |

📝 Recent Commits

- [`e1691661`](https://github.com/readest/readest/commit/e1691661) release: version 0.9.82 (#2155)
- [`bc8e419d`](https://github.com/readest/readest/commit/bc8e419d) compat(koplugin): make meta_hash extraction more robust for calibre conversions and metadata edits, fixes #1838 (#2154)
- [`ccad1ca0`](https://github.com/readest/readest/commit/ccad1ca0) Add support for mono theme (#2122) (#2153)
- [`75c315fc`](https://github.com/readest/readest/commit/75c315fc) fix(koplugin): only prompt network connection during interactive push progress, closes #2137 (#2152)
- [`bdef593c`](https://github.com/readest/readest/commit/bdef593c) feat: support global settings from library menu, closes #2140 (#2151)
- [`d8943fc0`](https://github.com/readest/readest/commit/d8943fc0) compat: normalize OKLCH color syntax for older iOS Safari, closes #990 (#2150)
- [`cdd274e5`](https://github.com/readest/readest/commit/cdd274e5) compat: add support for WebView down to version 92, closes #2139 (#2145)
- [`22307417`](https://github.com/readest/readest/commit/22307417) fix(i18n): apply system language on app start, closes #2141 (#2144)
- [`0e6950a6`](https://github.com/readest/readest/commit/0e6950a6) i18n: localization for notification title and text (#2143)
- [`1d4541e3`](https://github.com/readest/readest/commit/1d4541e3) feat: request manage external storage permission when changing data directory to sdcard root on Android (#2142)

[🔗 View full comparison](https://github.com/readest/readest/compare/519e222...e169166)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
