### PR TITLE
update(apps/readest): update latest version to 0.9.88

### DIFF
--- a/apps/readest/Dockerfile
+++ b/apps/readest/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG READEST_VERSION=v0.9.87
+ARG READEST_VERSION=v0.9.88
 RUN git clone -b ${READEST_VERSION} --recurse-submodules https://github.com/readest/readest .
 
 FROM node:22-slim AS base

--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,8 +7,8 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.9.87",
-      "sha": "4f11f437e19d1075c8ed726619d364bab27cc9a3",
+      "version": "0.9.88",
+      "sha": "05e9549410bb3ba8e26b5dee3a1472b3a8fcd1b0",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.9.87` → `0.9.88` | [`4f11f43`](https://github.com/readest/readest/commit/4f11f437e19d1075c8ed726619d364bab27cc9a3) → [`05e9549`](https://github.com/readest/readest/commit/05e9549410bb3ba8e26b5dee3a1472b3a8fcd1b0) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.9.88 (#2258) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2025-10-18T00:06:00+08:00Z |
| **Changed** | 43 files, +353/-53 |

📝 Recent Commits

- [`05e95494`](https://github.com/readest/readest/commit/05e95494) release: version 0.9.88 (#2258)
- [`35fbce35`](https://github.com/readest/readest/commit/35fbce35) feat(settings): added an option to disable animation in E-Ink mode, closes #2253 (#2257)
- [`c1d68257`](https://github.com/readest/readest/commit/c1d68257) fix: more sensitive snap to paginate, closes #2252 (#2256)
- [`ae6c6970`](https://github.com/readest/readest/commit/ae6c6970) feat: localize number in progress info in vertical layout (#2255)
- [`f8fef57c`](https://github.com/readest/readest/commit/f8fef57c) fix(layout): overriding book layout no longer overrides explicit text alignment, closes #2249 (#2254)
- [`4dc19173`](https://github.com/readest/readest/commit/4dc19173) fix(layout): prevent TTS indicator from disappearing too quickly to open configuration panel, closes #2247 (#2248)

[🔗 View full comparison](https://github.com/readest/readest/compare/4f11f43...05e9549)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
