### PR TITLE
update(apps/weserv): update latest version to 80a20bf, update alpine version to 80a20bf

### DIFF
--- a/apps/weserv/Dockerfile
+++ b/apps/weserv/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=e334ec7
+ARG VERSION=80a20bf
 ARG NGINX_VERSION=1.29.4
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 # Download NGINX source, because of rockylinux(arm64) can't extract it during build

--- a/apps/weserv/Dockerfile.alpine
+++ b/apps/weserv/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=e334ec7
+ARG VERSION=80a20bf
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 # Based on:

--- a/apps/weserv/meta.json
+++ b/apps/weserv/meta.json
@@ -5,8 +5,8 @@
   "description": "weserv 是一个用于快速生成图像的 API",
   "variants": {
     "latest": {
-      "version": "e334ec7",
-      "sha": "e334ec75fc6cde91aeddabfcae6369b14b933582",
+      "version": "80a20bf",
+      "sha": "80a20bf318e8a68152cf6e10887811baf5864de7",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",
@@ -21,8 +21,8 @@
       }
     },
     "alpine": {
-      "version": "e334ec7",
-      "sha": "e334ec75fc6cde91aeddabfcae6369b14b933582",
+      "version": "80a20bf",
+      "sha": "80a20bf318e8a68152cf6e10887811baf5864de7",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `weserv` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`weserv/images`](https://github.com/weserv/images) | `e334ec7` → `80a20bf` | [`e334ec7`](https://github.com/weserv/images/commit/e334ec75fc6cde91aeddabfcae6369b14b933582) → [`80a20bf`](https://github.com/weserv/images/commit/80a20bf318e8a68152cf6e10887811baf5864de7) |
| `alpine` | [`weserv/images`](https://github.com/weserv/images) | `e334ec7` → `80a20bf` | [`e334ec7`](https://github.com/weserv/images/commit/e334ec75fc6cde91aeddabfcae6369b14b933582) → [`80a20bf`](https://github.com/weserv/images/commit/80a20bf318e8a68152cf6e10887811baf5864de7) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.18.2 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-04-10T17:36:24+08:00Z |
| **Changed** | 9 files, +17/-19 |

📝 Recent Commits

- [`80a20bf`](https://github.com/weserv/images/commit/80a20bf) Bump GitHub Actions libvips to 8.18.2
- [`e49cf84`](https://github.com/weserv/images/commit/e49cf84) Bump Catch2 subproject dependency to 3.14.0
- [`6e57477`](https://github.com/weserv/images/commit/6e57477) CI: Upgrade `codecov/codecov-action` to v6
- [`478cbc5`](https://github.com/weserv/images/commit/478cbc5) Simplify nginx configuration
- [`0218234`](https://github.com/weserv/images/commit/0218234) Update nginx to 1.29.8
- [`3cca5e9`](https://github.com/weserv/images/commit/3cca5e9) Prefer integer convolution for mild blur/sharpen ops

[🔗 View full comparison](https://github.com/weserv/images/compare/e334ec7...80a20bf)

</p></details>

<details><summary>alpine</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.18.2 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-04-10T17:36:24+08:00Z |
| **Changed** | 9 files, +17/-19 |

📝 Recent Commits

- [`80a20bf`](https://github.com/weserv/images/commit/80a20bf) Bump GitHub Actions libvips to 8.18.2
- [`e49cf84`](https://github.com/weserv/images/commit/e49cf84) Bump Catch2 subproject dependency to 3.14.0
- [`6e57477`](https://github.com/weserv/images/commit/6e57477) CI: Upgrade `codecov/codecov-action` to v6
- [`478cbc5`](https://github.com/weserv/images/commit/478cbc5) Simplify nginx configuration
- [`0218234`](https://github.com/weserv/images/commit/0218234) Update nginx to 1.29.8
- [`3cca5e9`](https://github.com/weserv/images/commit/3cca5e9) Prefer integer convolution for mild blur/sharpen ops

[🔗 View full comparison](https://github.com/weserv/images/compare/e334ec7...80a20bf)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
