### PR TITLE
update(apps/readest): update latest version to 0.10.6, update test version to 0.10.6

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.10.4",
-      "sha": "3174e341a3c2886d827ef8a8a0ea16cef6311c06",
+      "version": "0.10.6",
+      "sha": "1088af023b83c8fcf3ff30be64e4335f534c9bf3",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.10.4",
-      "sha": "3174e341a3c2886d827ef8a8a0ea16cef6311c06",
+      "version": "0.10.6",
+      "sha": "1088af023b83c8fcf3ff30be64e4335f534c9bf3",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.10.4"
+VERSION="v0.10.6"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.10.4"
+VERSION="v0.10.6"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.10.4` → `0.10.6` | [`3174e34`](https://github.com/readest/readest/commit/3174e341a3c2886d827ef8a8a0ea16cef6311c06) → [`1088af0`](https://github.com/readest/readest/commit/1088af023b83c8fcf3ff30be64e4335f534c9bf3) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.10.4` → `0.10.6` | [`3174e34`](https://github.com/readest/readest/commit/3174e341a3c2886d827ef8a8a0ea16cef6311c06) → [`1088af0`](https://github.com/readest/readest/commit/1088af023b83c8fcf3ff30be64e4335f534c9bf3) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.10.6 (#3861) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-04-13T18:55:13+08:00Z |
| **Changed** | 177 files, +6959/-2199 |

📝 Recent Commits

- [`1088af02`](https://github.com/readest/readest/commit/1088af02) release: version 0.10.6 (#3861)
- [`011ad18a`](https://github.com/readest/readest/commit/011ad18a) fix(android): use stable safe area insets to avoid unnecessary layout shift, closes #3670 (#3859)
- [`e9d71b29`](https://github.com/readest/readest/commit/e9d71b29) feat(settings): add an option to avoid overriding paragraph layout, closes #3824 (#3858)
- [`ec326145`](https://github.com/readest/readest/commit/ec326145) fix(settings): fixed color picker for custom highlight colors, closes #3796 (#3857)
- [`96678d85`](https://github.com/readest/readest/commit/96678d85) refactor(settings): persist the apply-globally toggle per book (#3856)
- [`41b5e925`](https://github.com/readest/readest/commit/41b5e925) feat(annotator): support instant copy operation for selected text, closes #3828 (#3854)
- [`ef97a8ed`](https://github.com/readest/readest/commit/ef97a8ed) fix(ux): optimize scrolling UX for the bookshelf and sidebar content (#3849)
- [`8df8bc8b`](https://github.com/readest/readest/commit/8df8bc8b) chore(agent): use claude in chrome for web based qa (#3847)
- [`f0e23a15`](https://github.com/readest/readest/commit/f0e23a15) fix(linux): update package installation for Linux-x64 (#3845)
- [`4e1464ef`](https://github.com/readest/readest/commit/4e1464ef) fix(macOS): don&#39;t show window button when traffic lights are on the header, closes #3831 (#3843)

[🔗 View full comparison](https://github.com/readest/readest/compare/3174e34...1088af0)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.10.6 (#3861) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-04-13T18:55:13+08:00Z |
| **Changed** | 177 files, +6959/-2199 |

📝 Recent Commits

- [`1088af02`](https://github.com/readest/readest/commit/1088af02) release: version 0.10.6 (#3861)
- [`011ad18a`](https://github.com/readest/readest/commit/011ad18a) fix(android): use stable safe area insets to avoid unnecessary layout shift, closes #3670 (#3859)
- [`e9d71b29`](https://github.com/readest/readest/commit/e9d71b29) feat(settings): add an option to avoid overriding paragraph layout, closes #3824 (#3858)
- [`ec326145`](https://github.com/readest/readest/commit/ec326145) fix(settings): fixed color picker for custom highlight colors, closes #3796 (#3857)
- [`96678d85`](https://github.com/readest/readest/commit/96678d85) refactor(settings): persist the apply-globally toggle per book (#3856)
- [`41b5e925`](https://github.com/readest/readest/commit/41b5e925) feat(annotator): support instant copy operation for selected text, closes #3828 (#3854)
- [`ef97a8ed`](https://github.com/readest/readest/commit/ef97a8ed) fix(ux): optimize scrolling UX for the bookshelf and sidebar content (#3849)
- [`8df8bc8b`](https://github.com/readest/readest/commit/8df8bc8b) chore(agent): use claude in chrome for web based qa (#3847)
- [`f0e23a15`](https://github.com/readest/readest/commit/f0e23a15) fix(linux): update package installation for Linux-x64 (#3845)
- [`4e1464ef`](https://github.com/readest/readest/commit/4e1464ef) fix(macOS): don&#39;t show window button when traffic lights are on the header, closes #3831 (#3843)

[🔗 View full comparison](https://github.com/readest/readest/compare/3174e34...1088af0)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
