### PR TITLE
update(apps/excalidraw): update latest version to 0.18.0, update dev version to 1caec99

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -6,6 +6,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
+      "version": "0.18.0",
+      "sha": "817d8c553c3389650f8b4503984a6d4a5d2f0c11",
       "checkver": {
         "type": "tag",
         "repo": "excalidraw/excalidraw",
@@ -19,6 +21,8 @@
       }
     },
     "dev": {
+      "version": "1caec99",
+      "sha": "1caec99b290c75cda05385e637138998807a65ae",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="{{version}}"
+VERSION="1caec99"
 
 # Clone the repository
 mkdir -p app && cd app

--- a/apps/excalidraw/pre.sh
+++ b/apps/excalidraw/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="{{version}}"
+VERSION="0.18.0"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `N/A` → `0.18.0` | `N/A` → [`817d8c5`](https://github.com/excalidraw/excalidraw/commit/817d8c553c3389650f8b4503984a6d4a5d2f0c11) |
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `N/A` → `1caec99` | `N/A` → [`1caec99`](https://github.com/excalidraw/excalidraw/commit/1caec99b290c75cda05385e637138998807a65ae) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | docs: update CHANGELOG (#9243) |
| **Author** | Marcel Mraz &lt;marcel@excalidraw.com&gt; |
| **Date** | 2025-03-11T20:44:10+08:00Z |
| **Changed** | 796 files, +100233/-47643 |

📝 Recent Commits

- [`817d8c55`](https://github.com/excalidraw/excalidraw/commit/817d8c55) docs: update CHANGELOG (#9243)
- [`69bc5bda`](https://github.com/excalidraw/excalidraw/commit/69bc5bda) chore: post publish docs &amp; examples changes (#9217)
- [`d587b8a3`](https://github.com/excalidraw/excalidraw/commit/d587b8a3) fix: Do not rebind undragged elbow arrow endpoint (#9191)
- [`4ec812bc`](https://github.com/excalidraw/excalidraw/commit/4ec812bc) fix: Bound elbow arrow on duplication does not route correctly (#9236)
- [`a9e2d234`](https://github.com/excalidraw/excalidraw/commit/a9e2d234) chore: Logging and fixing extremely large scenes (#9225)
- [`70c3e921`](https://github.com/excalidraw/excalidraw/commit/70c3e921) fix: package env vars (#9221)
- [`d92384b7`](https://github.com/excalidraw/excalidraw/commit/d92384b7) revert: `vite@6` -&gt; `vite@5` (#9220)
- [`c5d3bb0b`](https://github.com/excalidraw/excalidraw/commit/c5d3bb0b) fix: #8475 Arrow updated on both sides (#8593)
- [`d21c6a1b`](https://github.com/excalidraw/excalidraw/commit/d21c6a1b) chore: bump vite@6.x (#9210)
- [`d1112bbf`](https://github.com/excalidraw/excalidraw/commit/d1112bbf) fix: docked sidebar width (#9213)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/commits/817d8c5)

</p></details>

<details><summary>dev</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | docs: change twitter label by X (#11158) |
| **Author** | Tom Louveau &lt;chewie.louveau@gmail.com&gt; |
| **Date** | 2026-04-13T16:30:58+08:00Z |
| **Changed** | N/A |

📝 Recent Commits

- [`1caec99b`](https://github.com/excalidraw/excalidraw/commit/1caec99b) docs: change twitter label by X (#11158)
- [`e18c1dd2`](https://github.com/excalidraw/excalidraw/commit/e18c1dd2) Fix typo in Discord badge URL parameter (#11096)
- [`d9e8a33a`](https://github.com/excalidraw/excalidraw/commit/d9e8a33a) feat(editor): implement overlap box selection (#11053)
- [`4be4cc0e`](https://github.com/excalidraw/excalidraw/commit/4be4cc0e) fix: pin 9 actions to commit SHA (#11075)
- [`4a5c9e99`](https://github.com/excalidraw/excalidraw/commit/4a5c9e99) fix(editor): ensure font picker font names are not quoted (#11036)
- [`c09e170b`](https://github.com/excalidraw/excalidraw/commit/c09e170b) feat(editor): deselect on esc (#11035)
- [`c1082923`](https://github.com/excalidraw/excalidraw/commit/c1082923) feat(editor): support mermaid staate diagrams (#11031)
- [`1c292e49`](https://github.com/excalidraw/excalidraw/commit/1c292e49) fix(math): correctly validate second point in isLineSegment (#11007)
- [`d6f0f34f`](https://github.com/excalidraw/excalidraw/commit/d6f0f34f) fix: Rotated rounded arrow center point (#10962)
- [`75789f62`](https://github.com/excalidraw/excalidraw/commit/75789f62) fix: Other endpoint is not immediately updated on midpoint snap (#10933)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/commits/1caec99)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
