### PR TITLE
update(apps/memogram): update latest version to 0.5.0

### DIFF
--- a/apps/memogram/Dockerfile
+++ b/apps/memogram/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git AS source
 WORKDIR /app
-ARG VERSION=v0.4.2
+ARG VERSION=v0.5.0
 RUN git clone --branch ${VERSION} https://github.com/usememos/telegram-integration .
 
 # Build stage

--- a/apps/memogram/meta.json
+++ b/apps/memogram/meta.json
@@ -7,8 +7,8 @@
   "license": "Custom properties",
   "variants": {
     "latest": {
-      "version": "0.4.2",
-      "sha": "ae833095b8006e7bf9636e7ed4517df9943812e9",
+      "version": "0.5.0",
+      "sha": "ea70bc8d8f8468dc86c446504dfa1000ea11a3ef",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/usememos/telegram-integration"


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `memogram` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`usememos/telegram-integration`](https://github.com/usememos/telegram-integration) | `0.4.2` → `0.5.0` | [`ae83309`](https://github.com/usememos/telegram-integration/commit/ae833095b8006e7bf9636e7ed4517df9943812e9) → [`ea70bc8`](https://github.com/usememos/telegram-integration/commit/ea70bc8d8f8468dc86c446504dfa1000ea11a3ef) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`usememos/telegram-integration`](https://github.com/usememos/telegram-integration) |
| **Latest Commit** | fix(ci): use module Go version for releases |
| **Author** | Steven &lt;stevenlgtm@gmail.com&gt; |
| **Date** | 2026-04-19T22:30:34+08:00Z |
| **Changed** | 5 files, +108/-49 |

📝 Recent Commits

- [`ea70bc8`](https://github.com/usememos/telegram-integration/commit/ea70bc8) fix(ci): use module Go version for releases
- [`e31f8d4`](https://github.com/usememos/telegram-integration/commit/e31f8d4) feat: migrate to memos 0.27.1
- [`cd42be8`](https://github.com/usememos/telegram-integration/commit/cd42be8) chore: bump github.com/go-telegram/bot from 1.19.0 to 1.20.0 (#185)

[🔗 View full comparison](https://github.com/usememos/telegram-integration/compare/ae83309...ea70bc8)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
