### PR TITLE
update(apps/excalidraw): update dev version to b1c6bfc

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "1caec99",
-      "sha": "1caec99b290c75cda05385e637138998807a65ae",
+      "version": "b1c6bfc",
+      "sha": "b1c6bfcf40cba255d208d8d525060684b10cb3cc",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="1caec99"
+VERSION="b1c6bfc"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `1caec99` → `b1c6bfc` | [`1caec99`](https://github.com/excalidraw/excalidraw/commit/1caec99b290c75cda05385e637138998807a65ae) → [`b1c6bfc`](https://github.com/excalidraw/excalidraw/commit/b1c6bfcf40cba255d208d8d525060684b10cb3cc) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | chore(docker): bump node (#11208) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-04-21T04:07:00+08:00Z |
| **Changed** | 2 files, +3/-3 |

📝 Recent Commits

- [`b1c6bfcf`](https://github.com/excalidraw/excalidraw/commit/b1c6bfcf) chore(docker): bump node (#11208)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/1caec99...b1c6bfc)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
