### PR TITLE
update(apps/excalidraw): update latest version to 0.18.1

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "0.18.0",
-      "sha": "817d8c553c3389650f8b4503984a6d4a5d2f0c11",
+      "version": "0.18.1",
+      "sha": "a2ec2889babf7d2295469c6d90ebe77fae57df84",
       "checkver": {
         "type": "tag",
         "repo": "excalidraw/excalidraw",

--- a/apps/excalidraw/pre.sh
+++ b/apps/excalidraw/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="0.18.0"
+VERSION="0.18.1"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `0.18.0` → `0.18.1` | [`817d8c5`](https://github.com/excalidraw/excalidraw/commit/817d8c553c3389650f8b4503984a6d4a5d2f0c11) → [`a2ec288`](https://github.com/excalidraw/excalidraw/commit/a2ec2889babf7d2295469c6d90ebe77fae57df84) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix: backport mermaid xss fix to 0.18.1 |
| **Author** | dwelle &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-04-21T04:30:38+08:00Z |
| **Changed** | 5 files, +557/-384 |

📝 Recent Commits

- [`a2ec2889`](https://github.com/excalidraw/excalidraw/commit/a2ec2889) fix: backport mermaid xss fix to 0.18.1

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/817d8c5...a2ec288)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
