### PR TITLE
update(apps/excalidraw): update dev version to 2e1a529

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "b1c6bfc",
-      "sha": "b1c6bfcf40cba255d208d8d525060684b10cb3cc",
+      "version": "2e1a529",
+      "sha": "2e1a529c6781b1534d27ca79198dccd40b97ec7b",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="b1c6bfc"
+VERSION="2e1a529"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `b1c6bfc` → `2e1a529` | [`b1c6bfc`](https://github.com/excalidraw/excalidraw/commit/b1c6bfcf40cba255d208d8d525060684b10cb3cc) → [`2e1a529`](https://github.com/excalidraw/excalidraw/commit/2e1a529c6781b1534d27ca79198dccd40b97ec7b) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): remove extremely large arrows on restore (#11235) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-04-25T18:03:50+08:00Z |
| **Changed** | 4 files, +49/-14 |

📝 Recent Commits

- [`2e1a529c`](https://github.com/excalidraw/excalidraw/commit/2e1a529c) fix(editor): remove extremely large arrows on restore (#11235)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/b1c6bfc...2e1a529)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
