### PR TITLE
update(apps/dashboard-icons): update latest version to da5bfe6

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "596692b",
-      "sha": "596692bc282f36de7b00758e33dd8b7d832b0cf9",
+      "version": "da5bfe6",
+      "sha": "da5bfe6dfc4386997d3b56eff9aa61661f2eb68d",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="596692b"
+VERSION="da5bfe6"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `596692b` → `da5bfe6` | [`596692b`](https://github.com/homarr-labs/dashboard-icons/commit/596692bc282f36de7b00758e33dd8b7d832b0cf9) → [`da5bfe6`](https://github.com/homarr-labs/dashboard-icons/commit/da5bfe6dfc4386997d3b56eff9aa61661f2eb68d) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | Merge pull request #2834 from homarr-labs/dependabot/npm_and_yarn/web/next-16.2.3 |
| **Author** | Thomas &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-04-27T23:25:30+08:00Z |
| **Changed** | 2 files, +57/-57 |

📝 Recent Commits

- [`da5bfe6d`](https://github.com/homarr-labs/dashboard-icons/commit/da5bfe6d) Merge pull request #2834 from homarr-labs/dependabot/npm_and_yarn/web/next-16.2.3
- [`cc76f5af`](https://github.com/homarr-labs/dashboard-icons/commit/cc76f5af) build(deps): bump next from 16.1.7 to 16.2.3 in /web

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/596692b...da5bfe6)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
