### PR TITLE
update(apps/excalidraw): update dev version to 43fa4b5

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "2e1a529",
-      "sha": "2e1a529c6781b1534d27ca79198dccd40b97ec7b",
+      "version": "43fa4b5",
+      "sha": "43fa4b56028478f53dbb65045df1f9f7737c4321",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="2e1a529"
+VERSION="43fa4b5"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `2e1a529` → `43fa4b5` | [`2e1a529`](https://github.com/excalidraw/excalidraw/commit/2e1a529c6781b1534d27ca79198dccd40b97ec7b) → [`43fa4b5`](https://github.com/excalidraw/excalidraw/commit/43fa4b56028478f53dbb65045df1f9f7737c4321) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix: frame selection and membership (#11250) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-04-29T00:23:10+08:00Z |
| **Changed** | 4 files, +76/-8 |

📝 Recent Commits

- [`43fa4b56`](https://github.com/excalidraw/excalidraw/commit/43fa4b56) fix: frame selection and membership (#11250)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/2e1a529...43fa4b5)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
