### PR TITLE
update(apps/excalidraw): update dev version to 278cd35

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "43fa4b5",
-      "sha": "43fa4b56028478f53dbb65045df1f9f7737c4321",
+      "version": "278cd35",
+      "sha": "278cd357724b17e1119b6c76416520c42958d0e3",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="43fa4b5"
+VERSION="278cd35"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `43fa4b5` → `278cd35` | [`43fa4b5`](https://github.com/excalidraw/excalidraw/commit/43fa4b56028478f53dbb65045df1f9f7737c4321) → [`278cd35`](https://github.com/excalidraw/excalidraw/commit/278cd357724b17e1119b6c76416520c42958d0e3) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(editor): scale video embeddables based on zoom (#11251) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-04-29T03:49:40+08:00Z |
| **Changed** | 2 files, +58/-25 |

📝 Recent Commits

- [`278cd357`](https://github.com/excalidraw/excalidraw/commit/278cd357) feat(editor): scale video embeddables based on zoom (#11251)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/43fa4b5...278cd35)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
