### PR TITLE
update(apps/rayso): update latest version to 0d30434

### DIFF
--- a/apps/rayso/meta.json
+++ b/apps/rayso/meta.json
@@ -6,8 +6,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "ddc8302",
-      "sha": "ddc8302531c5c1ec3f755c63a58210e2ac322935",
+      "version": "0d30434",
+      "sha": "0d3043401445b95dda1e96eda2a544d41febd881",
       "checkver": {
         "type": "sha",
         "repo": "raycast/ray-so"

--- a/apps/rayso/pre.sh
+++ b/apps/rayso/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="ddc8302"
+VERSION="0d30434"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `rayso` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`raycast/ray-so`](https://github.com/raycast/ray-so) | `ddc8302` → `0d30434` | [`ddc8302`](https://github.com/raycast/ray-so/commit/ddc8302531c5c1ec3f755c63a58210e2ac322935) → [`0d30434`](https://github.com/raycast/ray-so/commit/0d3043401445b95dda1e96eda2a544d41febd881) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`raycast/ray-so`](https://github.com/raycast/ray-so) |
| **Latest Commit** | Bump next from 16.2.0-canary.62 to 16.2.3 (#434) |
| **Author** | dependabot[bot] &lt;49699333+dependabot[bot]@users.noreply.github.com&gt; |
| **Date** | 2026-04-30T23:12:06+08:00Z |
| **Changed** | 2 files, +45/-45 |

📝 Recent Commits

- [`0d30434`](https://github.com/raycast/ray-so/commit/0d30434) Bump next from 16.2.0-canary.62 to 16.2.3 (#434)
- [`cbfd661`](https://github.com/raycast/ray-so/commit/cbfd661) Bump lodash-es from 4.17.23 to 4.18.1 (#432)

[🔗 View full comparison](https://github.com/raycast/ray-so/compare/ddc8302...0d30434)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
