### PR TITLE
update(apps/dashboard-icons): update latest version to f30e586

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "0ba7d98",
-      "sha": "0ba7d98c1016ea89c5b4d204b019769da9833d19",
+      "version": "f30e586",
+      "sha": "f30e5864037ef969190ebd6d793228ee3561ae50",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="0ba7d98"
+VERSION="f30e586"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `0ba7d98` → `f30e586` | [`0ba7d98`](https://github.com/homarr-labs/dashboard-icons/commit/0ba7d98c1016ea89c5b4d204b019769da9833d19) → [`f30e586`](https://github.com/homarr-labs/dashboard-icons/commit/f30e5864037ef969190ebd6d793228ee3561ae50) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | fix: show SVG customizer for all icons including gradients and external sources |
| **Author** | Thomas Camlong &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-05-02T02:10:06+08:00Z |
| **Changed** | 47 files, +5069/-2232 |

📝 Recent Commits

- [`f30e5864`](https://github.com/homarr-labs/dashboard-icons/commit/f30e5864) fix: show SVG customizer for all icons including gradients and external sources
- [`7cba0ece`](https://github.com/homarr-labs/dashboard-icons/commit/7cba0ece) repo upkeep
- [`cce7ce80`](https://github.com/homarr-labs/dashboard-icons/commit/cce7ce80) Merge pull request #2851 from homarr-labs/feat/svg-customizer-resilience
- [`83b62353`](https://github.com/homarr-labs/dashboard-icons/commit/83b62353) feat: make SVG color customizer resilient to all icon formats
- [`3dbe1db5`](https://github.com/homarr-labs/dashboard-icons/commit/3dbe1db5) Set npm as package ecosystem for Dependabot
- [`6c8c7362`](https://github.com/homarr-labs/dashboard-icons/commit/6c8c7362) Change dependabot directory to &#39;web&#39;
- [`9355dc93`](https://github.com/homarr-labs/dashboard-icons/commit/9355dc93) Merge pull request #2842 from homarr-labs/feat/seo-audit-ux
- [`cbe0ab6e`](https://github.com/homarr-labs/dashboard-icons/commit/cbe0ab6e) refactor: extract hero image URL to a single variable
- [`81104c06`](https://github.com/homarr-labs/dashboard-icons/commit/81104c06) feat(seo): add &quot;logo&quot; to image alt text in icon card and detail views
- [`ebd972c9`](https://github.com/homarr-labs/dashboard-icons/commit/ebd972c9) feat(seo): add metadata to 404 page with noindex

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/0ba7d98...f30e586)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
