### PR TITLE
update(apps/dashboard-icons): update latest version to 695eca1

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "cf621c1",
-      "sha": "cf621c1cb7b51391b97e590f0e8d644da390f7ed",
+      "version": "695eca1",
+      "sha": "695eca128436d64094d22b339b38d8c523969a25",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="cf621c1"
+VERSION="695eca1"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `cf621c1` → `695eca1` | [`cf621c1`](https://github.com/homarr-labs/dashboard-icons/commit/cf621c1cb7b51391b97e590f0e8d644da390f7ed) → [`695eca1`](https://github.com/homarr-labs/dashboard-icons/commit/695eca128436d64094d22b339b38d8c523969a25) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | refactor: simplify search bar button, icon card, icon search and sorting |
| **Author** | Thomas Camlong &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-05-02T04:59:11+08:00Z |
| **Changed** | 9 files, +209/-246 |

📝 Recent Commits

- [`695eca12`](https://github.com/homarr-labs/dashboard-icons/commit/695eca12) refactor: simplify search bar button, icon card, icon search and sorting
- [`50845434`](https://github.com/homarr-labs/dashboard-icons/commit/50845434) fix: command menu keyboard nav updates preview + remove dialog focus ring

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/cf621c1...695eca1)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
