### PR TITLE
update(apps/excalidraw): update dev version to 2dfcc6f

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "3f5fdec",
-      "sha": "3f5fdec04e2fdb7239432a436a6580c4d5e465b0",
+      "version": "2dfcc6f",
+      "sha": "2dfcc6f0ce4ce007e0360324e63f02ffc7b7fc1a",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="3f5fdec"
+VERSION="2dfcc6f"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `3f5fdec` → `2dfcc6f` | [`3f5fdec`](https://github.com/excalidraw/excalidraw/commit/3f5fdec04e2fdb7239432a436a6580c4d5e465b0) → [`2dfcc6f`](https://github.com/excalidraw/excalidraw/commit/2dfcc6f0ce4ce007e0360324e63f02ffc7b7fc1a) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | chore: Remove startBoundElement from state (#11264) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-05-02T22:36:42+08:00Z |
| **Changed** | 9 files, +56/-142 |

📝 Recent Commits

- [`2dfcc6f0`](https://github.com/excalidraw/excalidraw/commit/2dfcc6f0) chore: Remove startBoundElement from state (#11264)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/3f5fdec...2dfcc6f)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
