### PR TITLE
update(apps/excalidraw): update dev version to 3004c64

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "2dfcc6f",
-      "sha": "2dfcc6f0ce4ce007e0360324e63f02ffc7b7fc1a",
+      "version": "3004c64",
+      "sha": "3004c642dab239b4e060f7da5c3ac12d2dc9691d",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="2dfcc6f"
+VERSION="3004c64"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `2dfcc6f` → `3004c64` | [`2dfcc6f`](https://github.com/excalidraw/excalidraw/commit/2dfcc6f0ce4ce007e0360324e63f02ffc7b7fc1a) → [`3004c64`](https://github.com/excalidraw/excalidraw/commit/3004c642dab239b4e060f7da5c3ac12d2dc9691d) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix: Fractional index validation (#11258) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-05-04T17:37:17+08:00Z |
| **Changed** | 18 files, +508/-17 |

📝 Recent Commits

- [`3004c642`](https://github.com/excalidraw/excalidraw/commit/3004c642) fix: Fractional index validation (#11258)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/2dfcc6f...3004c64)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
