### PR TITLE
update(apps/dashboard-icons): update latest version to 9ce65c5

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "842ef7c",
-      "sha": "842ef7c1b475361741334161d8f54e42fc90e20d",
+      "version": "9ce65c5",
+      "sha": "9ce65c5e570e216c98706feb9f6fc60499078fad",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="842ef7c"
+VERSION="9ce65c5"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `842ef7c` → `9ce65c5` | [`842ef7c`](https://github.com/homarr-labs/dashboard-icons/commit/842ef7c1b475361741334161d8f54e42fc90e20d) → [`9ce65c5`](https://github.com/homarr-labs/dashboard-icons/commit/9ce65c5e570e216c98706feb9f6fc60499078fad) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | feat: use submitOrReplaceRejected in forms and show resubmit notice |
| **Author** | Thomas Camlong &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-05-06T17:45:42+08:00Z |
| **Changed** | 5 files, +59/-4 |

📝 Recent Commits

- [`9ce65c5e`](https://github.com/homarr-labs/dashboard-icons/commit/9ce65c5e) feat: use submitOrReplaceRejected in forms and show resubmit notice
- [`c30276f4`](https://github.com/homarr-labs/dashboard-icons/commit/c30276f4) feat: allow resubmission of rejected icons

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/842ef7c...9ce65c5)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
