### PR TITLE
update(apps/excalidraw): update dev version to c59fb8d

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "d255747",
-      "sha": "d2557474e2a9cfccd0a94ab950a2e763ab12823a",
+      "version": "c59fb8d",
+      "sha": "c59fb8dcbc8a63b5db2de5e0bfe49551f35ded7d",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="d255747"
+VERSION="c59fb8d"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `d255747` → `c59fb8d` | [`d255747`](https://github.com/excalidraw/excalidraw/commit/d2557474e2a9cfccd0a94ab950a2e763ab12823a) → [`c59fb8d`](https://github.com/excalidraw/excalidraw/commit/c59fb8dcbc8a63b5db2de5e0bfe49551f35ded7d) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix: LocalStorage is empty object on node@25 which breaks tests (#11240) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-05-06T23:42:36+08:00Z |
| **Changed** | 7 files, +434/-36 |

📝 Recent Commits

- [`c59fb8dc`](https://github.com/excalidraw/excalidraw/commit/c59fb8dc) fix: LocalStorage is empty object on node@25 which breaks tests (#11240)
- [`7f56cc0c`](https://github.com/excalidraw/excalidraw/commit/7f56cc0c) fix: Speculative fixes for arrow invariant failures (#11241)
- [`974b338b`](https://github.com/excalidraw/excalidraw/commit/974b338b) fix: Group selection (#11234)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/d255747...c59fb8d)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
