### PR TITLE
update(apps/excalidraw): update dev version to 97274a7

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "c59fb8d",
-      "sha": "c59fb8dcbc8a63b5db2de5e0bfe49551f35ded7d",
+      "version": "97274a7",
+      "sha": "97274a74b2d075d60335c4e9cd8dbf56de935df8",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="c59fb8d"
+VERSION="97274a7"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `c59fb8d` → `97274a7` | [`c59fb8d`](https://github.com/excalidraw/excalidraw/commit/c59fb8dcbc8a63b5db2de5e0bfe49551f35ded7d) → [`97274a7`](https://github.com/excalidraw/excalidraw/commit/97274a74b2d075d60335c4e9cd8dbf56de935df8) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | ci(repo): enforce scopes (#11292) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-05-07T01:54:30+08:00Z |
| **Changed** | 1 files, +86/-0 |

📝 Recent Commits

- [`97274a74`](https://github.com/excalidraw/excalidraw/commit/97274a74) ci(repo): enforce scopes (#11292)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/c59fb8d...97274a7)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
