### PR TITLE
update(apps/excalidraw): update dev version to b2b2815

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "97274a7",
-      "sha": "97274a74b2d075d60335c4e9cd8dbf56de935df8",
+      "version": "b2b2815",
+      "sha": "b2b2815954f6561f0980bef8997750dabec16e87",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="97274a7"
+VERSION="b2b2815"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `97274a7` → `b2b2815` | [`97274a7`](https://github.com/excalidraw/excalidraw/commit/97274a74b2d075d60335c4e9cd8dbf56de935df8) → [`b2b2815`](https://github.com/excalidraw/excalidraw/commit/b2b2815954f6561f0980bef8997750dabec16e87) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): prevent duplicate lasso toolbar item (#11286) |
| **Author** | Praneeth Kodumagulla &lt;64239307+praneethhere@users.noreply.github.com&gt; |
| **Date** | 2026-05-07T05:10:50+08:00Z |
| **Changed** | 4 files, +32/-10 |

📝 Recent Commits

- [`b2b28159`](https://github.com/excalidraw/excalidraw/commit/b2b28159) fix(editor): prevent duplicate lasso toolbar item (#11286)
- [`d992c10b`](https://github.com/excalidraw/excalidraw/commit/d992c10b) fix(app): resolve app-jotai import path in LocalData (#11290)
- [`091b9053`](https://github.com/excalidraw/excalidraw/commit/091b9053) fix(editor): enabled ctrl+y redo shortcut on linux and mac (#11179)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/97274a7...b2b2815)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
