### PR TITLE
update(apps/dashboard-icons): update latest version to 0055180

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "0564e7f",
-      "sha": "0564e7fbc95ebdfb962732ae90b33db90af16fe0",
+      "version": "0055180",
+      "sha": "00551801d43f7ba2334094f6fe1092c4f4f656d4",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="0564e7f"
+VERSION="0055180"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `0564e7f` → `0055180` | [`0564e7f`](https://github.com/homarr-labs/dashboard-icons/commit/0564e7fbc95ebdfb962732ae90b33db90af16fe0) → [`0055180`](https://github.com/homarr-labs/dashboard-icons/commit/00551801d43f7ba2334094f6fe1092c4f4f656d4) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | Merge pull request #2859 from homarr-labs/feat/improve-seo |
| **Author** | Thomas &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-05-08T00:29:09+08:00Z |
| **Changed** | 13 files, +1046/-43 |

📝 Recent Commits

- [`00551801`](https://github.com/homarr-labs/dashboard-icons/commit/00551801) Merge pull request #2859 from homarr-labs/feat/improve-seo
- [`0177ea07`](https://github.com/homarr-labs/dashboard-icons/commit/0177ea07) test: add OG image route handler tests for validation, 404s, cache headers, and bulk coverage
- [`e7a462be`](https://github.com/homarr-labs/dashboard-icons/commit/e7a462be) fix: address review feedback
- [`56566b11`](https://github.com/homarr-labs/dashboard-icons/commit/56566b11) SEO improvements
- [`0d175512`](https://github.com/homarr-labs/dashboard-icons/commit/0d175512) feat: improve SEO with OG images, breadcrumbs, structured data, and preconnect links
- [`cdcb2592`](https://github.com/homarr-labs/dashboard-icons/commit/cdcb2592) feat: fix selfsh.st icons display

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/0564e7f...0055180)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
