### PR TITLE
update(apps/readest): update latest version to 0.11.1, update test version to 0.11.1

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.10.6",
-      "sha": "1088af023b83c8fcf3ff30be64e4335f534c9bf3",
+      "version": "0.11.1",
+      "sha": "56d6aceb0da379b4581290da6cac3ea4f04aaafc",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.10.6",
-      "sha": "1088af023b83c8fcf3ff30be64e4335f534c9bf3",
+      "version": "0.11.1",
+      "sha": "56d6aceb0da379b4581290da6cac3ea4f04aaafc",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.10.6"
+VERSION="v0.11.1"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.10.6"
+VERSION="v0.11.1"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.10.6` → `0.11.1` | [`1088af0`](https://github.com/readest/readest/commit/1088af023b83c8fcf3ff30be64e4335f534c9bf3) → [`56d6ace`](https://github.com/readest/readest/commit/56d6aceb0da379b4581290da6cac3ea4f04aaafc) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.10.6` → `0.11.1` | [`1088af0`](https://github.com/readest/readest/commit/1088af023b83c8fcf3ff30be64e4335f534c9bf3) → [`56d6ace`](https://github.com/readest/readest/commit/56d6aceb0da379b4581290da6cac3ea4f04aaafc) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.1 (#4123) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-05-11T12:18:03+08:00Z |
| **Changed** | 625 files, +92529/-6469 |

📝 Recent Commits

- [`56d6aceb`](https://github.com/readest/readest/commit/56d6aceb) release: version 0.11.1 (#4123)
- [`598eb772`](https://github.com/readest/readest/commit/598eb772) feat(library): redesign empty-library onboarding (#4122)
- [`d326e1c7`](https://github.com/readest/readest/commit/d326e1c7) fix: hide popup triangle when inside popup + EPUB image-only paragraph rendering (#4121)
- [`1705006b`](https://github.com/readest/readest/commit/1705006b) fix(mobile): iOS PIN keyboard UX + Safari font line-height in EPUBs (#4120)
- [`952e4365`](https://github.com/readest/readest/commit/952e4365) i18n: update translations (#4118)
- [`772bb73b`](https://github.com/readest/readest/commit/772bb73b) ui/ux: codify design system and migrate settings to shared primitives (#4116)
- [`5774e00c`](https://github.com/readest/readest/commit/5774e00c) feat(sync): opt-in Credentials toggle + keyring v4 migration (#4111)
- [`f6f446e8`](https://github.com/readest/readest/commit/f6f446e8) feat(applock): blinking PIN cursor + misc UI polish (#4110)
- [`1eae2af2`](https://github.com/readest/readest/commit/1eae2af2) feat(sync): batch replica sync into one /api/sync/replicas request (#4109)
- [`295a5889`](https://github.com/readest/readest/commit/295a5889) feat(share): route annotation exports through the system share sheet (#4107)

[🔗 View full comparison](https://github.com/readest/readest/compare/1088af0...56d6ace)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.1 (#4123) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-05-11T12:18:03+08:00Z |
| **Changed** | 625 files, +92529/-6469 |

📝 Recent Commits

- [`56d6aceb`](https://github.com/readest/readest/commit/56d6aceb) release: version 0.11.1 (#4123)
- [`598eb772`](https://github.com/readest/readest/commit/598eb772) feat(library): redesign empty-library onboarding (#4122)
- [`d326e1c7`](https://github.com/readest/readest/commit/d326e1c7) fix: hide popup triangle when inside popup + EPUB image-only paragraph rendering (#4121)
- [`1705006b`](https://github.com/readest/readest/commit/1705006b) fix(mobile): iOS PIN keyboard UX + Safari font line-height in EPUBs (#4120)
- [`952e4365`](https://github.com/readest/readest/commit/952e4365) i18n: update translations (#4118)
- [`772bb73b`](https://github.com/readest/readest/commit/772bb73b) ui/ux: codify design system and migrate settings to shared primitives (#4116)
- [`5774e00c`](https://github.com/readest/readest/commit/5774e00c) feat(sync): opt-in Credentials toggle + keyring v4 migration (#4111)
- [`f6f446e8`](https://github.com/readest/readest/commit/f6f446e8) feat(applock): blinking PIN cursor + misc UI polish (#4110)
- [`1eae2af2`](https://github.com/readest/readest/commit/1eae2af2) feat(sync): batch replica sync into one /api/sync/replicas request (#4109)
- [`295a5889`](https://github.com/readest/readest/commit/295a5889) feat(share): route annotation exports through the system share sheet (#4107)

[🔗 View full comparison](https://github.com/readest/readest/compare/1088af0...56d6ace)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
