### PR TITLE
update(apps/excalidraw): update dev version to 0457ac9

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "b2b2815",
-      "sha": "b2b2815954f6561f0980bef8997750dabec16e87",
+      "version": "0457ac9",
+      "sha": "0457ac90634b8556feaa9c0e56be94d3f13fd9bd",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="b2b2815"
+VERSION="0457ac9"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `b2b2815` → `0457ac9` | [`b2b2815`](https://github.com/excalidraw/excalidraw/commit/b2b2815954f6561f0980bef8997750dabec16e87) → [`0457ac9`](https://github.com/excalidraw/excalidraw/commit/0457ac90634b8556feaa9c0e56be94d3f13fd9bd) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): handle invalid points on restore (#11321) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-05-13T00:44:49+08:00Z |
| **Changed** | 3 files, +183/-16 |

📝 Recent Commits

- [`0457ac90`](https://github.com/excalidraw/excalidraw/commit/0457ac90) fix(editor): handle invalid points on restore (#11321)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/b2b2815...0457ac9)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
