### PR TITLE
update(apps/excalidraw): update dev version to b42b1a1

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "f6d85bc",
-      "sha": "f6d85bc80fe328e8f472636eb0d541f7bb891aa0",
+      "version": "b42b1a1",
+      "sha": "b42b1a193d5311d319861cd925ba89ca073ab2d4",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="f6d85bc"
+VERSION="b42b1a1"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `f6d85bc` → `b42b1a1` | [`f6d85bc`](https://github.com/excalidraw/excalidraw/commit/f6d85bc80fe328e8f472636eb0d541f7bb891aa0) → [`b42b1a1`](https://github.com/excalidraw/excalidraw/commit/b42b1a193d5311d319861cd925ba89ca073ab2d4) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): excessive battery usage (#11377) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-05-24T22:12:17+08:00Z |
| **Changed** | 12 files, +282/-171 |

📝 Recent Commits

- [`b42b1a19`](https://github.com/excalidraw/excalidraw/commit/b42b1a19) fix(editor): excessive battery usage (#11377)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/f6d85bc...b42b1a1)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
