### PR TITLE
update(apps/dashboard-icons): update latest version to 962c4e9

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "0675404",
-      "sha": "0675404daa3150d967d149dab3cd94e8792010b1",
+      "version": "962c4e9",
+      "sha": "962c4e9fedcef3a9ec136f4d39b78dd083b2404c",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="0675404"
+VERSION="962c4e9"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `0675404` → `962c4e9` | [`0675404`](https://github.com/homarr-labs/dashboard-icons/commit/0675404daa3150d967d149dab3cd94e8792010b1) → [`962c4e9`](https://github.com/homarr-labs/dashboard-icons/commit/962c4e9fedcef3a9ec136f4d39b78dd083b2404c) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | fix: add middleware to consolidate www, HTTP, and tracking param variants |
| **Author** | Thomas Camlong &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-05-25T20:28:27+08:00Z |
| **Changed** | 7 files, +54/-12 |

📝 Recent Commits

- [`962c4e9f`](https://github.com/homarr-labs/dashboard-icons/commit/962c4e9f) fix: add middleware to consolidate www, HTTP, and tracking param variants
- [`e6b0ddc4`](https://github.com/homarr-labs/dashboard-icons/commit/e6b0ddc4) fix: exclude /og/ routes from Google indexing
- [`bc1f4b30`](https://github.com/homarr-labs/dashboard-icons/commit/bc1f4b30) ci(github-actions): convert SVG assets to PNG and WEBP
- [`4680309e`](https://github.com/homarr-labs/dashboard-icons/commit/4680309e) fix(ci): switch selfh.st sync workflow from pnpm to bun (#2865)

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/0675404...962c4e9)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
