### PR TITLE
update(apps/excalidraw): update dev version to c08be69

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "b42b1a1",
-      "sha": "b42b1a193d5311d319861cd925ba89ca073ab2d4",
+      "version": "c08be69",
+      "sha": "c08be69618dcac9386817bced03d2d79883e50b6",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="b42b1a1"
+VERSION="c08be69"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `b42b1a1` → `c08be69` | [`b42b1a1`](https://github.com/excalidraw/excalidraw/commit/b42b1a193d5311d319861cd925ba89ca073ab2d4) → [`c08be69`](https://github.com/excalidraw/excalidraw/commit/c08be69618dcac9386817bced03d2d79883e50b6) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | ci(docker): fix docker dep bundling and pin remaining actions (#11398) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-05-25T20:39:21+08:00Z |
| **Changed** | 10 files, +19/-19 |

📝 Recent Commits

- [`c08be696`](https://github.com/excalidraw/excalidraw/commit/c08be696) ci(docker): fix docker dep bundling and pin remaining actions (#11398)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/b42b1a1...c08be69)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
