### PR TITLE
update(apps/excalidraw): update dev version to b6d80e4

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "3372149",
-      "sha": "33721492771919e8569964fe0b034a9cf7f25955",
+      "version": "b6d80e4",
+      "sha": "b6d80e4256e718d14b2dc173315fb524f473320c",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="3372149"
+VERSION="b6d80e4"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `3372149` → `b6d80e4` | [`3372149`](https://github.com/excalidraw/excalidraw/commit/33721492771919e8569964fe0b034a9cf7f25955) → [`b6d80e4`](https://github.com/excalidraw/excalidraw/commit/b6d80e4256e718d14b2dc173315fb524f473320c) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(packages/excalidraw): consolidate bounds checks (#11275) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-06-05T01:27:25+08:00Z |
| **Changed** | 10 files, +382/-866 |

📝 Recent Commits

- [`b6d80e42`](https://github.com/excalidraw/excalidraw/commit/b6d80e42) fix(packages/excalidraw): consolidate bounds checks (#11275)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/3372149...b6d80e4)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
