### PR TITLE
update(apps/excalidraw): update dev version to 647a264

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "b6d80e4",
-      "sha": "b6d80e4256e718d14b2dc173315fb524f473320c",
+      "version": "647a264",
+      "sha": "647a264a485a33bf1bf2cec9adcc8cc2151b253c",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="b6d80e4"
+VERSION="647a264"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `b6d80e4` → `647a264` | [`b6d80e4`](https://github.com/excalidraw/excalidraw/commit/b6d80e4256e718d14b2dc173315fb524f473320c) → [`647a264`](https://github.com/excalidraw/excalidraw/commit/647a264a485a33bf1bf2cec9adcc8cc2151b253c) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(packages/excalidraw): consolidate theme state handling (#11453) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-06-07T00:18:06+08:00Z |
| **Changed** | 15 files, +95/-75 |

📝 Recent Commits

- [`647a264a`](https://github.com/excalidraw/excalidraw/commit/647a264a) feat(packages/excalidraw): consolidate theme state handling (#11453)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/b6d80e4...647a264)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
