### PR TITLE
update(apps/excalidraw): update dev version to 61fe15a

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "647a264",
-      "sha": "647a264a485a33bf1bf2cec9adcc8cc2151b253c",
+      "version": "61fe15a",
+      "sha": "61fe15a51d1a74e5edd564b366889ea8789aec1c",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="647a264"
+VERSION="61fe15a"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `647a264` → `61fe15a` | [`647a264`](https://github.com/excalidraw/excalidraw/commit/647a264a485a33bf1bf2cec9adcc8cc2151b253c) → [`61fe15a`](https://github.com/excalidraw/excalidraw/commit/61fe15a51d1a74e5edd564b366889ea8789aec1c) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): cardinal direction arrows with label are invisible in exported SVG (#11441) |
| **Author** | KrishhnaT &lt;krishhnatupedev@gmail.com&gt; |
| **Date** | 2026-06-08T01:19:44+08:00Z |
| **Changed** | 2 files, +51/-0 |

📝 Recent Commits

- [`61fe15a5`](https://github.com/excalidraw/excalidraw/commit/61fe15a5) fix(editor): cardinal direction arrows with label are invisible in exported SVG (#11441)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/647a264...61fe15a)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
