### PR TITLE
update(apps/weserv): update latest version to 8df2528, update alpine version to 8df2528

### DIFF
--- a/apps/weserv/Dockerfile
+++ b/apps/weserv/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=80a20bf
+ARG VERSION=8df2528
 ARG NGINX_VERSION=1.29.4
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 # Download NGINX source, because of rockylinux(arm64) can't extract it during build

--- a/apps/weserv/Dockerfile.alpine
+++ b/apps/weserv/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=80a20bf
+ARG VERSION=8df2528
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 # Based on:

--- a/apps/weserv/meta.json
+++ b/apps/weserv/meta.json
@@ -5,8 +5,8 @@
   "description": "weserv 是一个用于快速生成图像的 API",
   "variants": {
     "latest": {
-      "version": "80a20bf",
-      "sha": "80a20bf318e8a68152cf6e10887811baf5864de7",
+      "version": "8df2528",
+      "sha": "8df25289d44517156c07608fd45735f10d4e3b51",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",
@@ -21,8 +21,8 @@
       }
     },
     "alpine": {
-      "version": "80a20bf",
-      "sha": "80a20bf318e8a68152cf6e10887811baf5864de7",
+      "version": "8df2528",
+      "sha": "8df25289d44517156c07608fd45735f10d4e3b51",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `weserv` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`weserv/images`](https://github.com/weserv/images) | `80a20bf` → `8df2528` | [`80a20bf`](https://github.com/weserv/images/commit/80a20bf318e8a68152cf6e10887811baf5864de7) → [`8df2528`](https://github.com/weserv/images/commit/8df25289d44517156c07608fd45735f10d4e3b51) |
| `alpine` | [`weserv/images`](https://github.com/weserv/images) | `80a20bf` → `8df2528` | [`80a20bf`](https://github.com/weserv/images/commit/80a20bf318e8a68152cf6e10887811baf5864de7) → [`8df2528`](https://github.com/weserv/images/commit/8df25289d44517156c07608fd45735f10d4e3b51) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Update nginx to 1.31.1 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-06-09T00:10:55+08:00Z |
| **Changed** | 10 files, +116/-83 |

📝 Recent Commits

- [`8df2528`](https://github.com/weserv/images/commit/8df2528) Update nginx to 1.31.1
- [`d9235c7`](https://github.com/weserv/images/commit/d9235c7) Reject malformed hostnames
- [`410aa4e`](https://github.com/weserv/images/commit/410aa4e) Reject malformed upstream HTTP status lines
- [`27240f4`](https://github.com/weserv/images/commit/27240f4) Prevent possible int overflow in TIFF pyramid scanner
- [`a23d5d2`](https://github.com/weserv/images/commit/a23d5d2) Simplify integration tests
- [`3fd5d93`](https://github.com/weserv/images/commit/3fd5d93) Optimize `parse_url()`

[🔗 View full comparison](https://github.com/weserv/images/compare/80a20bf...8df2528)

</p></details>

<details><summary>alpine</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Update nginx to 1.31.1 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-06-09T00:10:55+08:00Z |
| **Changed** | 10 files, +116/-83 |

📝 Recent Commits

- [`8df2528`](https://github.com/weserv/images/commit/8df2528) Update nginx to 1.31.1
- [`d9235c7`](https://github.com/weserv/images/commit/d9235c7) Reject malformed hostnames
- [`410aa4e`](https://github.com/weserv/images/commit/410aa4e) Reject malformed upstream HTTP status lines
- [`27240f4`](https://github.com/weserv/images/commit/27240f4) Prevent possible int overflow in TIFF pyramid scanner
- [`a23d5d2`](https://github.com/weserv/images/commit/a23d5d2) Simplify integration tests
- [`3fd5d93`](https://github.com/weserv/images/commit/3fd5d93) Optimize `parse_url()`

[🔗 View full comparison](https://github.com/weserv/images/compare/80a20bf...8df2528)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
