### PR TITLE
update(apps/dashboard-icons): update latest version to cfc8706

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "0987c30",
-      "sha": "0987c30bf9f2fa94e1d3216be42501cacebd531f",
+      "version": "cfc8706",
+      "sha": "cfc87065bbfcb718b6dcfbc63035bbedd143a5a7",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="0987c30"
+VERSION="cfc8706"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `0987c30` → `cfc8706` | [`0987c30`](https://github.com/homarr-labs/dashboard-icons/commit/0987c30bf9f2fa94e1d3216be42501cacebd531f) → [`cfc8706`](https://github.com/homarr-labs/dashboard-icons/commit/cfc87065bbfcb718b6dcfbc63035bbedd143a5a7) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | ci(github-actions): convert SVG assets to PNG and WEBP |
| **Author** | Dashboard Icons Bot &lt;homarr-labs@proton.me&gt; |
| **Date** | 2026-06-09T21:06:18+08:00Z |
| **Changed** | 7 files, +9/-3 |

📝 Recent Commits

- [`cfc87065`](https://github.com/homarr-labs/dashboard-icons/commit/cfc87065) ci(github-actions): convert SVG assets to PNG and WEBP
- [`e841e832`](https://github.com/homarr-labs/dashboard-icons/commit/e841e832) chore: add icon &quot;paperless&quot; (submission vk4crmrzbxd1av0, approved by ajnart)

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/0987c30...cfc8706)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
