### PR TITLE
update(apps/excalidraw): update dev version to 0cf56b1

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "61fe15a",
-      "sha": "61fe15a51d1a74e5edd564b366889ea8789aec1c",
+      "version": "0cf56b1",
+      "sha": "0cf56b19c79a28dda52f0dcb1c5392ed19cb5fcd",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="61fe15a"
+VERSION="0cf56b1"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `61fe15a` → `0cf56b1` | [`61fe15a`](https://github.com/excalidraw/excalidraw/commit/61fe15a51d1a74e5edd564b366889ea8789aec1c) → [`0cf56b1`](https://github.com/excalidraw/excalidraw/commit/0cf56b19c79a28dda52f0dcb1c5392ed19cb5fcd) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | test(editor): add unit tests for BinaryHeap (#11419) |
| **Author** | KrishhnaT &lt;krishhnatupedev@gmail.com&gt; |
| **Date** | 2026-06-10T23:12:42+08:00Z |
| **Changed** | 1 files, +109/-0 |

📝 Recent Commits

- [`0cf56b19`](https://github.com/excalidraw/excalidraw/commit/0cf56b19) test(editor): add unit tests for BinaryHeap (#11419)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/61fe15a...0cf56b1)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
