### PR TITLE
update(base/vscode): update latest version to 1.123.2, update stable version to 1.123.2

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.123.1
+ARG VERSION=1.123.2
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.123.1 -> 1.123.1.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.123.2 -> 1.123.2.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.123.1
+ARG VERSION=1.123.2
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.123.1 -> 1.123.1.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.123.2 -> 1.123.2.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.123.1",
-      "sha": "8b5bd2a8dd195a2bc76e8848f7ce8a3c323c020a",
+      "version": "1.123.2",
+      "sha": "73b30e61dd53c0223a1f112031f2fec0267b4dff",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -21,8 +21,8 @@
       }
     },
     "stable": {
-      "version": "1.123.1",
-      "sha": "8b5bd2a8dd195a2bc76e8848f7ce8a3c323c020a",
+      "version": "1.123.2",
+      "sha": "73b30e61dd53c0223a1f112031f2fec0267b4dff",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.123.1` → `1.123.2` | [`8b5bd2a`](https://github.com/microsoft/vscode/commit/8b5bd2a8dd195a2bc76e8848f7ce8a3c323c020a) → [`73b30e6`](https://github.com/microsoft/vscode/commit/73b30e61dd53c0223a1f112031f2fec0267b4dff) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.123.1` → `1.123.2` | [`8b5bd2a`](https://github.com/microsoft/vscode/commit/8b5bd2a8dd195a2bc76e8848f7ce8a3c323c020a) → [`73b30e6`](https://github.com/microsoft/vscode/commit/73b30e61dd53c0223a1f112031f2fec0267b4dff) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Block auto-approve for tilde and env-var expansions in file write paths (#42) (#320676) |
| **Author** | Megan Rogge &lt;merogge@microsoft.com&gt; |
| **Date** | 2026-06-10T14:06:17+08:00Z |
| **Changed** | 6 files, +18/-9 |

📝 Recent Commits

- [`73b30e61dd5`](https://github.com/microsoft/vscode/commit/73b30e61dd5) Block auto-approve for tilde and env-var expansions in file write paths (#42) (#320676)
- [`0024d884c7d`](https://github.com/microsoft/vscode/commit/0024d884c7d) Bump version to 1.123.2 (#320652)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/8b5bd2a...73b30e6)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Block auto-approve for tilde and env-var expansions in file write paths (#42) (#320676) |
| **Author** | Megan Rogge &lt;merogge@microsoft.com&gt; |
| **Date** | 2026-06-10T14:06:17+08:00Z |
| **Changed** | 6 files, +18/-9 |

📝 Recent Commits

- [`73b30e61dd5`](https://github.com/microsoft/vscode/commit/73b30e61dd5) Block auto-approve for tilde and env-var expansions in file write paths (#42) (#320676)
- [`0024d884c7d`](https://github.com/microsoft/vscode/commit/0024d884c7d) Bump version to 1.123.2 (#320652)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/8b5bd2a...73b30e6)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
