### PR TITLE
update(base/vscode): update latest version to 1.124.0, update stable version to 1.124.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.123.2
+ARG VERSION=1.124.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.123.2 -> 1.123.2.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.124.0 -> 1.124.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.123.2
+ARG VERSION=1.124.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.123.2 -> 1.123.2.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.124.0 -> 1.124.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.123.2",
-      "sha": "73b30e61dd53c0223a1f112031f2fec0267b4dff",
+      "version": "1.124.0",
+      "sha": "1b50d58d73426c9171299ec4037d01365d995b78",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.123.2",
-      "sha": "73b30e61dd53c0223a1f112031f2fec0267b4dff",
+      "version": "1.124.0",
+      "sha": "1b50d58d73426c9171299ec4037d01365d995b78",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.123.2` → `1.124.0` | [`73b30e6`](https://github.com/microsoft/vscode/commit/73b30e61dd53c0223a1f112031f2fec0267b4dff) → [`1b50d58`](https://github.com/microsoft/vscode/commit/1b50d58d73426c9171299ec4037d01365d995b78) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.123.2` → `1.124.0` | [`73b30e6`](https://github.com/microsoft/vscode/commit/73b30e61dd53c0223a1f112031f2fec0267b4dff) → [`1b50d58`](https://github.com/microsoft/vscode/commit/1b50d58d73426c9171299ec4037d01365d995b78) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Cherry pick/msrc 1.123 to release 1.123 (#55) (#320698) |
| **Author** | dileepyavan &lt;52841896+dileepyavan@users.noreply.github.com&gt; |
| **Date** | 2026-06-10T12:29:32+08:00Z |
| **Changed** | 1365 files, +49811/-10633 |

📝 Recent Commits

- [`1b50d58d734`](https://github.com/microsoft/vscode/commit/1b50d58d734) Cherry pick/msrc 1.123 to release 1.123 (#55) (#320698)
- [`a118f82c785`](https://github.com/microsoft/vscode/commit/a118f82c785) [cherry-pick] Fix session part re-entrancy issue (#320620)
- [`285114401f6`](https://github.com/microsoft/vscode/commit/285114401f6) Background terminal notifications: preserve agent and run on conversation model (1.124) (#320642)
- [`ad3036df97c`](https://github.com/microsoft/vscode/commit/ad3036df97c) [release/1.124] Cherry-pick MSRC fixes (#320655)
- [`38b6dd3f3ea`](https://github.com/microsoft/vscode/commit/38b6dd3f3ea) [cherry-pick] sessions: make per-workspace session limit configurable via ExP (#320597)
- [`dff9767b128`](https://github.com/microsoft/vscode/commit/dff9767b128) Update link to permission level docs (release branch) (#320569)
- [`4a7406909d8`](https://github.com/microsoft/vscode/commit/4a7406909d8) [cherry-pick] sessions: experiment to move harness picker below input (#320586)
- [`a9580a647de`](https://github.com/microsoft/vscode/commit/a9580a647de) [Cherry-pick release/1.124] Pick up current and future Claude models for tool search and prompt routing (#320519)
- [`b2206f10687`](https://github.com/microsoft/vscode/commit/b2206f10687) Render keybindings for OpenInVSCode and OpenWorkspaceInAgents widgets (#320507)
- [`beaa8c7f7f4`](https://github.com/microsoft/vscode/commit/beaa8c7f7f4) [cherry-pick] Fix web fetch tool for signed-out BYOK scenario (#320364)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/73b30e6...1b50d58)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Cherry pick/msrc 1.123 to release 1.123 (#55) (#320698) |
| **Author** | dileepyavan &lt;52841896+dileepyavan@users.noreply.github.com&gt; |
| **Date** | 2026-06-10T12:29:32+08:00Z |
| **Changed** | 1365 files, +49811/-10633 |

📝 Recent Commits

- [`1b50d58d734`](https://github.com/microsoft/vscode/commit/1b50d58d734) Cherry pick/msrc 1.123 to release 1.123 (#55) (#320698)
- [`a118f82c785`](https://github.com/microsoft/vscode/commit/a118f82c785) [cherry-pick] Fix session part re-entrancy issue (#320620)
- [`285114401f6`](https://github.com/microsoft/vscode/commit/285114401f6) Background terminal notifications: preserve agent and run on conversation model (1.124) (#320642)
- [`ad3036df97c`](https://github.com/microsoft/vscode/commit/ad3036df97c) [release/1.124] Cherry-pick MSRC fixes (#320655)
- [`38b6dd3f3ea`](https://github.com/microsoft/vscode/commit/38b6dd3f3ea) [cherry-pick] sessions: make per-workspace session limit configurable via ExP (#320597)
- [`dff9767b128`](https://github.com/microsoft/vscode/commit/dff9767b128) Update link to permission level docs (release branch) (#320569)
- [`4a7406909d8`](https://github.com/microsoft/vscode/commit/4a7406909d8) [cherry-pick] sessions: experiment to move harness picker below input (#320586)
- [`a9580a647de`](https://github.com/microsoft/vscode/commit/a9580a647de) [Cherry-pick release/1.124] Pick up current and future Claude models for tool search and prompt routing (#320519)
- [`b2206f10687`](https://github.com/microsoft/vscode/commit/b2206f10687) Render keybindings for OpenInVSCode and OpenWorkspaceInAgents widgets (#320507)
- [`beaa8c7f7f4`](https://github.com/microsoft/vscode/commit/beaa8c7f7f4) [cherry-pick] Fix web fetch tool for signed-out BYOK scenario (#320364)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/73b30e6...1b50d58)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
