### PR TITLE
update(apps/readest): update latest version to 0.11.4, update test version to 0.11.4

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.2",
-      "sha": "97e2aa279716212a41c87aeb038e744d0b10e504",
+      "version": "0.11.4",
+      "sha": "27fa9ab22648361ca66f17fbc47fdc94c42bae41",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.2",
-      "sha": "97e2aa279716212a41c87aeb038e744d0b10e504",
+      "version": "0.11.4",
+      "sha": "27fa9ab22648361ca66f17fbc47fdc94c42bae41",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.2"
+VERSION="v0.11.4"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.2"
+VERSION="v0.11.4"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.2` → `0.11.4` | [`97e2aa2`](https://github.com/readest/readest/commit/97e2aa279716212a41c87aeb038e744d0b10e504) → [`27fa9ab`](https://github.com/readest/readest/commit/27fa9ab22648361ca66f17fbc47fdc94c42bae41) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.2` → `0.11.4` | [`97e2aa2`](https://github.com/readest/readest/commit/97e2aa279716212a41c87aeb038e744d0b10e504) → [`27fa9ab`](https://github.com/readest/readest/commit/27fa9ab22648361ca66f17fbc47fdc94c42bae41) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | chore(i18n): translate new strings; commit pending agent memory notes (#4430) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-03T01:01:47+08:00Z |
| **Changed** | 118 files, +4562/-544 |

📝 Recent Commits

- [`27fa9ab2`](https://github.com/readest/readest/commit/27fa9ab2) chore(i18n): translate new strings; commit pending agent memory notes (#4430)
- [`c2bbb611`](https://github.com/readest/readest/commit/c2bbb611) fix(reader): keep paginated page background inside its column (#4394) (#4429)
- [`578b7ba1`](https://github.com/readest/readest/commit/578b7ba1) fix(reader): restore annotation list auto-scroll to the nearest item (#4428)
- [`9d8062ae`](https://github.com/readest/readest/commit/9d8062ae) fix(reader): keep table background matching the page in dark mode (#4419) (#4426)
- [`7128e896`](https://github.com/readest/readest/commit/7128e896) fix(reader): suppress Android image callout freezing the image viewer (#4425)
- [`e4bb9fc4`](https://github.com/readest/readest/commit/e4bb9fc4) refactor(share): make saveFile content nullable for path-based shares (#4424)
- [`df66c63a`](https://github.com/readest/readest/commit/df66c63a) fix(txt): recover author for 【】-titled web-novel TXT imports, closes #4390 (#4423)
- [`963bab0f`](https://github.com/readest/readest/commit/963bab0f) fix(library): stop bookshelf context menu shuffling its order (#4389) (#4421)
- [`f9ddddb6`](https://github.com/readest/readest/commit/f9ddddb6) fix(library): use ghost cancel buttons in migrate-data dialog for e-ink (#4396) (#4422)
- [`fe853554`](https://github.com/readest/readest/commit/fe853554) feat(library): send book file from bookshelf selection popup (#4402)

[🔗 View full comparison](https://github.com/readest/readest/compare/97e2aa2...27fa9ab)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | chore(i18n): translate new strings; commit pending agent memory notes (#4430) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-03T01:01:47+08:00Z |
| **Changed** | 118 files, +4562/-544 |

📝 Recent Commits

- [`27fa9ab2`](https://github.com/readest/readest/commit/27fa9ab2) chore(i18n): translate new strings; commit pending agent memory notes (#4430)
- [`c2bbb611`](https://github.com/readest/readest/commit/c2bbb611) fix(reader): keep paginated page background inside its column (#4394) (#4429)
- [`578b7ba1`](https://github.com/readest/readest/commit/578b7ba1) fix(reader): restore annotation list auto-scroll to the nearest item (#4428)
- [`9d8062ae`](https://github.com/readest/readest/commit/9d8062ae) fix(reader): keep table background matching the page in dark mode (#4419) (#4426)
- [`7128e896`](https://github.com/readest/readest/commit/7128e896) fix(reader): suppress Android image callout freezing the image viewer (#4425)
- [`e4bb9fc4`](https://github.com/readest/readest/commit/e4bb9fc4) refactor(share): make saveFile content nullable for path-based shares (#4424)
- [`df66c63a`](https://github.com/readest/readest/commit/df66c63a) fix(txt): recover author for 【】-titled web-novel TXT imports, closes #4390 (#4423)
- [`963bab0f`](https://github.com/readest/readest/commit/963bab0f) fix(library): stop bookshelf context menu shuffling its order (#4389) (#4421)
- [`f9ddddb6`](https://github.com/readest/readest/commit/f9ddddb6) fix(library): use ghost cancel buttons in migrate-data dialog for e-ink (#4396) (#4422)
- [`fe853554`](https://github.com/readest/readest/commit/fe853554) feat(library): send book file from bookshelf selection popup (#4402)

[🔗 View full comparison](https://github.com/readest/readest/compare/97e2aa2...27fa9ab)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
