### PR TITLE
update(apps/excalidraw): update dev version to b324a85

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "a83ac48",
-      "sha": "a83ac488536dbf4bc4dcf1f472f72ce3b4bd2073",
+      "version": "b324a85",
+      "sha": "b324a85ab1c53d1a96b351cdb4e9292cd41cab6d",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="a83ac48"
+VERSION="b324a85"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `a83ac48` → `b324a85` | [`a83ac48`](https://github.com/excalidraw/excalidraw/commit/a83ac488536dbf4bc4dcf1f472f72ce3b4bd2073) → [`b324a85`](https://github.com/excalidraw/excalidraw/commit/b324a85ab1c53d1a96b351cdb4e9292cd41cab6d) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): elements duplicated when moving frame children (#11485) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-06-14T02:32:45+08:00Z |
| **Changed** | 2 files, +255/-3 |

📝 Recent Commits

- [`b324a85a`](https://github.com/excalidraw/excalidraw/commit/b324a85a) fix(editor): elements duplicated when moving frame children (#11485)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/a83ac48...b324a85)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
