### PR TITLE
update(apps/excalidraw): update dev version to 28a9b17

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "0699826",
-      "sha": "069982606dd7178c13e6c2293ede756c6767d3bc",
+      "version": "28a9b17",
+      "sha": "28a9b1711dc0625b8ab5d643dc871810ee13642f",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="0699826"
+VERSION="28a9b17"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `0699826` → `28a9b17` | [`0699826`](https://github.com/excalidraw/excalidraw/commit/069982606dd7178c13e6c2293ede756c6767d3bc) → [`28a9b17`](https://github.com/excalidraw/excalidraw/commit/28a9b1711dc0625b8ab5d643dc871810ee13642f) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | test(repo): less noisy test output (#11505) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-06-16T00:19:20+08:00Z |
| **Changed** | 7 files, +208/-102 |

📝 Recent Commits

- [`28a9b171`](https://github.com/excalidraw/excalidraw/commit/28a9b171) test(repo): less noisy test output (#11505)
- [`1cb9fff5`](https://github.com/excalidraw/excalidraw/commit/1cb9fff5) fix(editor): Double history (#11445)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/0699826...28a9b17)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
