### PR TITLE
update(apps/weserv): update latest version to 3fc989c, update alpine version to 3fc989c

### DIFF
--- a/apps/weserv/Dockerfile
+++ b/apps/weserv/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=8df2528
+ARG VERSION=3fc989c
 ARG NGINX_VERSION=1.29.4
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 # Download NGINX source, because of rockylinux(arm64) can't extract it during build

--- a/apps/weserv/Dockerfile.alpine
+++ b/apps/weserv/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=8df2528
+ARG VERSION=3fc989c
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 # Based on:

--- a/apps/weserv/meta.json
+++ b/apps/weserv/meta.json
@@ -5,8 +5,8 @@
   "description": "weserv 是一个用于快速生成图像的 API",
   "variants": {
     "latest": {
-      "version": "8df2528",
-      "sha": "8df25289d44517156c07608fd45735f10d4e3b51",
+      "version": "3fc989c",
+      "sha": "3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",
@@ -21,8 +21,8 @@
       }
     },
     "alpine": {
-      "version": "8df2528",
-      "sha": "8df25289d44517156c07608fd45735f10d4e3b51",
+      "version": "3fc989c",
+      "sha": "3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `weserv` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`weserv/images`](https://github.com/weserv/images) | `8df2528` → `3fc989c` | [`8df2528`](https://github.com/weserv/images/commit/8df25289d44517156c07608fd45735f10d4e3b51) → [`3fc989c`](https://github.com/weserv/images/commit/3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac) |
| `alpine` | [`weserv/images`](https://github.com/weserv/images) | `8df2528` → `3fc989c` | [`8df2528`](https://github.com/weserv/images/commit/8df25289d44517156c07608fd45735f10d4e3b51) → [`3fc989c`](https://github.com/weserv/images/commit/3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.18.3 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-06-18T02:53:12+08:00Z |
| **Changed** | 3 files, +3/-53 |

📝 Recent Commits

- [`3fc989c`](https://github.com/weserv/images/commit/3fc989c) Bump GitHub Actions libvips to 8.18.3
- [`7813b5b`](https://github.com/weserv/images/commit/7813b5b) CI: Migrate to GitHub-managed CodeQL configuration
- [`681926c`](https://github.com/weserv/images/commit/681926c) Update Alpine base image to version 3.24

[🔗 View full comparison](https://github.com/weserv/images/compare/8df2528...3fc989c)

</p></details>

<details><summary>alpine</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.18.3 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-06-18T02:53:12+08:00Z |
| **Changed** | 3 files, +3/-53 |

📝 Recent Commits

- [`3fc989c`](https://github.com/weserv/images/commit/3fc989c) Bump GitHub Actions libvips to 8.18.3
- [`7813b5b`](https://github.com/weserv/images/commit/7813b5b) CI: Migrate to GitHub-managed CodeQL configuration
- [`681926c`](https://github.com/weserv/images/commit/681926c) Update Alpine base image to version 3.24

[🔗 View full comparison](https://github.com/weserv/images/compare/8df2528...3fc989c)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
