### PR TITLE
update(apps/readest): update latest version to 0.11.10, update test version to 0.11.10

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.4",
-      "sha": "27fa9ab22648361ca66f17fbc47fdc94c42bae41",
+      "version": "0.11.10",
+      "sha": "d8953353cf1d3bac8e37e80fe2f43193d3def281",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.4",
-      "sha": "27fa9ab22648361ca66f17fbc47fdc94c42bae41",
+      "version": "0.11.10",
+      "sha": "d8953353cf1d3bac8e37e80fe2f43193d3def281",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.4"
+VERSION="v0.11.10"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.4"
+VERSION="v0.11.10"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.4` → `0.11.10` | [`27fa9ab`](https://github.com/readest/readest/commit/27fa9ab22648361ca66f17fbc47fdc94c42bae41) → [`d895335`](https://github.com/readest/readest/commit/d8953353cf1d3bac8e37e80fe2f43193d3def281) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.4` → `0.11.10` | [`27fa9ab`](https://github.com/readest/readest/commit/27fa9ab22648361ca66f17fbc47fdc94c42bae41) → [`d895335`](https://github.com/readest/readest/commit/d8953353cf1d3bac8e37e80fe2f43193d3def281) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.10 (#4667) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-19T22:04:31+08:00Z |
| **Changed** | 607 files, +49448/-3062 |

📝 Recent Commits

- [`d8953353`](https://github.com/readest/readest/commit/d8953353) release: version 0.11.10 (#4667)
- [`78109814`](https://github.com/readest/readest/commit/78109814) fix(koplugin): repair reading-stats sync push/pull (#4666)
- [`dd53e524`](https://github.com/readest/readest/commit/dd53e524) chore: only show the current position item in TOC and update agent memories (#4665)
- [`b7585ac4`](https://github.com/readest/readest/commit/b7585ac4) chore(send-to-readest): add Chrome Web Store screenshot generator (#4664)
- [`6caa376f`](https://github.com/readest/readest/commit/6caa376f) feat(reader): Webtoon Mode seamless continuous scroll for image books (#3647) (#4662)
- [`590c44f9`](https://github.com/readest/readest/commit/590c44f9) fix(send-to-readest): rephrase popup copy and remove em dashes from i18n strings (#4663)
- [`4cb608be`](https://github.com/readest/readest/commit/4cb608be) chore(send-to-readest): v0.2.1, zip packaging script, store submission doc (#4661)
- [`1faa931a`](https://github.com/readest/readest/commit/1faa931a) fix(txt): stop detecting measure-word prose as chapters in TXT import (#4658) (#4660)
- [`86f55027`](https://github.com/readest/readest/commit/86f55027) fix: bot-review robustness fixes (TTS sync, updater, nightly, a11y) (#4659)
- [`e327d0c9`](https://github.com/readest/readest/commit/e327d0c9) feat(tts): reuse the speaking session across paragraph &amp; RSVP modes (#4657)

[🔗 View full comparison](https://github.com/readest/readest/compare/27fa9ab...d895335)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.10 (#4667) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-19T22:04:31+08:00Z |
| **Changed** | 607 files, +49448/-3062 |

📝 Recent Commits

- [`d8953353`](https://github.com/readest/readest/commit/d8953353) release: version 0.11.10 (#4667)
- [`78109814`](https://github.com/readest/readest/commit/78109814) fix(koplugin): repair reading-stats sync push/pull (#4666)
- [`dd53e524`](https://github.com/readest/readest/commit/dd53e524) chore: only show the current position item in TOC and update agent memories (#4665)
- [`b7585ac4`](https://github.com/readest/readest/commit/b7585ac4) chore(send-to-readest): add Chrome Web Store screenshot generator (#4664)
- [`6caa376f`](https://github.com/readest/readest/commit/6caa376f) feat(reader): Webtoon Mode seamless continuous scroll for image books (#3647) (#4662)
- [`590c44f9`](https://github.com/readest/readest/commit/590c44f9) fix(send-to-readest): rephrase popup copy and remove em dashes from i18n strings (#4663)
- [`4cb608be`](https://github.com/readest/readest/commit/4cb608be) chore(send-to-readest): v0.2.1, zip packaging script, store submission doc (#4661)
- [`1faa931a`](https://github.com/readest/readest/commit/1faa931a) fix(txt): stop detecting measure-word prose as chapters in TXT import (#4658) (#4660)
- [`86f55027`](https://github.com/readest/readest/commit/86f55027) fix: bot-review robustness fixes (TTS sync, updater, nightly, a11y) (#4659)
- [`e327d0c9`](https://github.com/readest/readest/commit/e327d0c9) feat(tts): reuse the speaking session across paragraph &amp; RSVP modes (#4657)

[🔗 View full comparison](https://github.com/readest/readest/compare/27fa9ab...d895335)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
