### PR TITLE
update(apps/readest): update latest version to 0.11.12, update test version to 0.11.12

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.10",
-      "sha": "d8953353cf1d3bac8e37e80fe2f43193d3def281",
+      "version": "0.11.12",
+      "sha": "54d54791b0873d29f5b5850a46340aa3a74cb51b",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.10",
-      "sha": "d8953353cf1d3bac8e37e80fe2f43193d3def281",
+      "version": "0.11.12",
+      "sha": "54d54791b0873d29f5b5850a46340aa3a74cb51b",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.10"
+VERSION="v0.11.12"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.10"
+VERSION="v0.11.12"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.10` → `0.11.12` | [`d895335`](https://github.com/readest/readest/commit/d8953353cf1d3bac8e37e80fe2f43193d3def281) → [`54d5479`](https://github.com/readest/readest/commit/54d54791b0873d29f5b5850a46340aa3a74cb51b) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.10` → `0.11.12` | [`d895335`](https://github.com/readest/readest/commit/d8953353cf1d3bac8e37e80fe2f43193d3def281) → [`54d5479`](https://github.com/readest/readest/commit/54d54791b0873d29f5b5850a46340aa3a74cb51b) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.12 (#4682) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-20T12:41:25+08:00Z |
| **Changed** | 90 files, +1464/-145 |

📝 Recent Commits

- [`54d54791`](https://github.com/readest/readest/commit/54d54791) release: version 0.11.12 (#4682)
- [`7185dca1`](https://github.com/readest/readest/commit/7185dca1) feat(reader): add save/share button to image gallery toolbar (#4680)
- [`a9526377`](https://github.com/readest/readest/commit/a9526377) fix(reader): stretch Duokan fullscreen cover to fill the page (#4679)
- [`f7e1bddd`](https://github.com/readest/readest/commit/f7e1bddd) fix(sync): stop re-pinning statusless books to the top of the library after every sync (#4677)
- [`0ab8f604`](https://github.com/readest/readest/commit/0ab8f604) fix(reader): keep cover background-image visible under a texture (#4675)
- [`5f561504`](https://github.com/readest/readest/commit/5f561504) fix(sync): keep view settings device-local and exclude them from sync (#4672)
- [`b9a3ee72`](https://github.com/readest/readest/commit/b9a3ee72) fix(opds): make saved catalog card hover distinct from dialog background (#4673)
- [`23d1ef6f`](https://github.com/readest/readest/commit/23d1ef6f) fix(rsvp): restore in-flow control bar layout reverted by #4589 (#4671)
- [`6e9faaa8`](https://github.com/readest/readest/commit/6e9faaa8) fix(pdf): throttle PDF range reads to fix large-file OOM on Android/iOS (#3470) (#4670)
- [`d5c64099`](https://github.com/readest/readest/commit/d5c64099) fix(opds): show Add Catalog dialog above Settings on mobile (#4669)

[🔗 View full comparison](https://github.com/readest/readest/compare/d895335...54d5479)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.12 (#4682) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-20T12:41:25+08:00Z |
| **Changed** | 90 files, +1464/-145 |

📝 Recent Commits

- [`54d54791`](https://github.com/readest/readest/commit/54d54791) release: version 0.11.12 (#4682)
- [`7185dca1`](https://github.com/readest/readest/commit/7185dca1) feat(reader): add save/share button to image gallery toolbar (#4680)
- [`a9526377`](https://github.com/readest/readest/commit/a9526377) fix(reader): stretch Duokan fullscreen cover to fill the page (#4679)
- [`f7e1bddd`](https://github.com/readest/readest/commit/f7e1bddd) fix(sync): stop re-pinning statusless books to the top of the library after every sync (#4677)
- [`0ab8f604`](https://github.com/readest/readest/commit/0ab8f604) fix(reader): keep cover background-image visible under a texture (#4675)
- [`5f561504`](https://github.com/readest/readest/commit/5f561504) fix(sync): keep view settings device-local and exclude them from sync (#4672)
- [`b9a3ee72`](https://github.com/readest/readest/commit/b9a3ee72) fix(opds): make saved catalog card hover distinct from dialog background (#4673)
- [`23d1ef6f`](https://github.com/readest/readest/commit/23d1ef6f) fix(rsvp): restore in-flow control bar layout reverted by #4589 (#4671)
- [`6e9faaa8`](https://github.com/readest/readest/commit/6e9faaa8) fix(pdf): throttle PDF range reads to fix large-file OOM on Android/iOS (#3470) (#4670)
- [`d5c64099`](https://github.com/readest/readest/commit/d5c64099) fix(opds): show Add Catalog dialog above Settings on mobile (#4669)

[🔗 View full comparison](https://github.com/readest/readest/compare/d895335...54d5479)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
