### PR TITLE
update(apps/weserv): update latest version to 82c0144, update alpine version to 82c0144

### DIFF
--- a/apps/weserv/Dockerfile
+++ b/apps/weserv/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=3fc989c
+ARG VERSION=82c0144
 ARG NGINX_VERSION=1.29.4
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 # Download NGINX source, because of rockylinux(arm64) can't extract it during build

--- a/apps/weserv/Dockerfile.alpine
+++ b/apps/weserv/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=3fc989c
+ARG VERSION=82c0144
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 # Based on:

--- a/apps/weserv/meta.json
+++ b/apps/weserv/meta.json
@@ -5,8 +5,8 @@
   "description": "weserv 是一个用于快速生成图像的 API",
   "variants": {
     "latest": {
-      "version": "3fc989c",
-      "sha": "3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac",
+      "version": "82c0144",
+      "sha": "82c0144059bb9eda91177bd922d5625ddf74dfab",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",
@@ -21,8 +21,8 @@
       }
     },
     "alpine": {
-      "version": "3fc989c",
-      "sha": "3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac",
+      "version": "82c0144",
+      "sha": "82c0144059bb9eda91177bd922d5625ddf74dfab",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `weserv` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`weserv/images`](https://github.com/weserv/images) | `3fc989c` → `82c0144` | [`3fc989c`](https://github.com/weserv/images/commit/3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac) → [`82c0144`](https://github.com/weserv/images/commit/82c0144059bb9eda91177bd922d5625ddf74dfab) |
| `alpine` | [`weserv/images`](https://github.com/weserv/images) | `3fc989c` → `82c0144` | [`3fc989c`](https://github.com/weserv/images/commit/3fc989c62ed5d68dc8d4fc3439c4ed489c3449ac) → [`82c0144`](https://github.com/weserv/images/commit/82c0144059bb9eda91177bd922d5625ddf74dfab) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | CI: Upgrade `codecov/codecov-action` to v7 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-06-22T17:49:12+08:00Z |
| **Changed** | 17 files, +124/-119 |

📝 Recent Commits

- [`82c0144`](https://github.com/weserv/images/commit/82c0144) CI: Upgrade `codecov/codecov-action` to v7
- [`bfa4dc0`](https://github.com/weserv/images/commit/bfa4dc0) CI: Upgrade `actions/checkout` to v7
- [`c3facc2`](https://github.com/weserv/images/commit/c3facc2) Update nginx to 1.31.2
- [`a8cca5f`](https://github.com/weserv/images/commit/a8cca5f) Rename `weserv_max_pages` directive to `weserv_limit_input_pages`
- [`0634606`](https://github.com/weserv/images/commit/0634606) Add the `weserv_limit_input_channels` directive
- [`b99a07f`](https://github.com/weserv/images/commit/b99a07f) Use correct check for oddness
- [`5349c3e`](https://github.com/weserv/images/commit/5349c3e) Make enum initialization consistent
- [`16a6924`](https://github.com/weserv/images/commit/16a6924) Remove commented-out code
- [`f723bd5`](https://github.com/weserv/images/commit/f723bd5) Format code according to clang-format

[🔗 View full comparison](https://github.com/weserv/images/compare/3fc989c...82c0144)

</p></details>

<details><summary>alpine</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | CI: Upgrade `codecov/codecov-action` to v7 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-06-22T17:49:12+08:00Z |
| **Changed** | 17 files, +124/-119 |

📝 Recent Commits

- [`82c0144`](https://github.com/weserv/images/commit/82c0144) CI: Upgrade `codecov/codecov-action` to v7
- [`bfa4dc0`](https://github.com/weserv/images/commit/bfa4dc0) CI: Upgrade `actions/checkout` to v7
- [`c3facc2`](https://github.com/weserv/images/commit/c3facc2) Update nginx to 1.31.2
- [`a8cca5f`](https://github.com/weserv/images/commit/a8cca5f) Rename `weserv_max_pages` directive to `weserv_limit_input_pages`
- [`0634606`](https://github.com/weserv/images/commit/0634606) Add the `weserv_limit_input_channels` directive
- [`b99a07f`](https://github.com/weserv/images/commit/b99a07f) Use correct check for oddness
- [`5349c3e`](https://github.com/weserv/images/commit/5349c3e) Make enum initialization consistent
- [`16a6924`](https://github.com/weserv/images/commit/16a6924) Remove commented-out code
- [`f723bd5`](https://github.com/weserv/images/commit/f723bd5) Format code according to clang-format

[🔗 View full comparison](https://github.com/weserv/images/compare/3fc989c...82c0144)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
