### PR TITLE
update(apps/excalidraw): update dev version to 0642e72

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "28a9b17",
-      "sha": "28a9b1711dc0625b8ab5d643dc871810ee13642f",
+      "version": "0642e72",
+      "sha": "0642e72cfa2d9a71198200e52f37399384610ee3",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="28a9b17"
+VERSION="0642e72"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `28a9b17` → `0642e72` | [`28a9b17`](https://github.com/excalidraw/excalidraw/commit/28a9b1711dc0625b8ab5d643dc871810ee13642f) → [`0642e72`](https://github.com/excalidraw/excalidraw/commit/0642e72cfa2d9a71198200e52f37399384610ee3) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): Arrows with text are rendered blurry in PNG export with larger scale (#11492) |
| **Author** | zsviczian &lt;viczian.zsolt@gmail.com&gt; |
| **Date** | 2026-06-23T00:22:26+08:00Z |
| **Changed** | 1 files, +39/-52 |

📝 Recent Commits

- [`0642e72c`](https://github.com/excalidraw/excalidraw/commit/0642e72c) fix(editor): Arrows with text are rendered blurry in PNG export with larger scale (#11492)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/28a9b17...0642e72)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
