### PR TITLE
update(base/vscode): update latest version to 1.126.0, update stable version to 1.126.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.125.0
+ARG VERSION=1.126.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.125.0 -> 1.125.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.126.0 -> 1.126.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.125.0
+ARG VERSION=1.126.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.125.0 -> 1.125.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.126.0 -> 1.126.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.125.0",
-      "sha": "93cfdd489c3b228840d0f86ec77c3636277c93ea",
+      "version": "1.126.0",
+      "sha": "7e7950df89d055b5a378379db9ee14290772148a",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.125.0",
-      "sha": "93cfdd489c3b228840d0f86ec77c3636277c93ea",
+      "version": "1.126.0",
+      "sha": "7e7950df89d055b5a378379db9ee14290772148a",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.125.0` → `1.126.0` | [`93cfdd4`](https://github.com/microsoft/vscode/commit/93cfdd489c3b228840d0f86ec77c3636277c93ea) → [`7e7950d`](https://github.com/microsoft/vscode/commit/7e7950df89d055b5a378379db9ee14290772148a) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.125.0` → `1.126.0` | [`93cfdd4`](https://github.com/microsoft/vscode/commit/93cfdd489c3b228840d0f86ec77c3636277c93ea) → [`7e7950d`](https://github.com/microsoft/vscode/commit/7e7950df89d055b5a378379db9ee14290772148a) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | [cherry-pick] Update GPT-5.5 prompt instructions (#322447) |
| **Author** | vs-code-engineering[bot] &lt;122617954+vs-code-engineering[bot]@users.noreply.github.com&gt; |
| **Date** | 2026-06-23T09:46:13+08:00Z |
| **Changed** | 1159 files, +102459/-61515 |

📝 Recent Commits

- [`7e7950df89d`](https://github.com/microsoft/vscode/commit/7e7950df89d) [cherry-pick] Update GPT-5.5 prompt instructions (#322447)
- [`d13e3d41761`](https://github.com/microsoft/vscode/commit/d13e3d41761) [cherry-pick] Fix dotted line styling in hover (#322455)
- [`fdbda702941`](https://github.com/microsoft/vscode/commit/fdbda702941) Revert forceFistExecutionInSandbox (#322477)
- [`bc1869d296f`](https://github.com/microsoft/vscode/commit/bc1869d296f) [cherry-pick] nes: update defaults for current file budgeting (#322394)
- [`450b816feda`](https://github.com/microsoft/vscode/commit/450b816feda) Merge pull request #321848 from microsoft/zhichli/otelmonitor
- [`b16421d711d`](https://github.com/microsoft/vscode/commit/b16421d711d) Merge branch &#39;main&#39; into zhichli/otelmonitor
- [`33341c02f9f`](https://github.com/microsoft/vscode/commit/33341c02f9f) agent host: fix subagent message leak on session reopen (#322311)
- [`7c5106058ba`](https://github.com/microsoft/vscode/commit/7c5106058ba) Sandbox: force execution in sandbox before model elevation using ForceExecuteInSandbox setting (#322320)
- [`e6f4d6c6f29`](https://github.com/microsoft/vscode/commit/e6f4d6c6f29) Avoid CPU-pegging process report in libc detection (#322260)
- [`bda1d1c3063`](https://github.com/microsoft/vscode/commit/bda1d1c3063) Add info logs to diagnose stuck &quot;running&quot; session status (#322309)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/93cfdd4...7e7950d)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | [cherry-pick] Update GPT-5.5 prompt instructions (#322447) |
| **Author** | vs-code-engineering[bot] &lt;122617954+vs-code-engineering[bot]@users.noreply.github.com&gt; |
| **Date** | 2026-06-23T09:46:13+08:00Z |
| **Changed** | 1159 files, +102459/-61515 |

📝 Recent Commits

- [`7e7950df89d`](https://github.com/microsoft/vscode/commit/7e7950df89d) [cherry-pick] Update GPT-5.5 prompt instructions (#322447)
- [`d13e3d41761`](https://github.com/microsoft/vscode/commit/d13e3d41761) [cherry-pick] Fix dotted line styling in hover (#322455)
- [`fdbda702941`](https://github.com/microsoft/vscode/commit/fdbda702941) Revert forceFistExecutionInSandbox (#322477)
- [`bc1869d296f`](https://github.com/microsoft/vscode/commit/bc1869d296f) [cherry-pick] nes: update defaults for current file budgeting (#322394)
- [`450b816feda`](https://github.com/microsoft/vscode/commit/450b816feda) Merge pull request #321848 from microsoft/zhichli/otelmonitor
- [`b16421d711d`](https://github.com/microsoft/vscode/commit/b16421d711d) Merge branch &#39;main&#39; into zhichli/otelmonitor
- [`33341c02f9f`](https://github.com/microsoft/vscode/commit/33341c02f9f) agent host: fix subagent message leak on session reopen (#322311)
- [`7c5106058ba`](https://github.com/microsoft/vscode/commit/7c5106058ba) Sandbox: force execution in sandbox before model elevation using ForceExecuteInSandbox setting (#322320)
- [`e6f4d6c6f29`](https://github.com/microsoft/vscode/commit/e6f4d6c6f29) Avoid CPU-pegging process report in libc detection (#322260)
- [`bda1d1c3063`](https://github.com/microsoft/vscode/commit/bda1d1c3063) Add info logs to diagnose stuck &quot;running&quot; session status (#322309)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/93cfdd4...7e7950d)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
