### PR TITLE
update(apps/excalidraw): update dev version to 2a82821

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "070df27",
-      "sha": "070df27e4d18cdc9265c9a9692089fe90b6019da",
+      "version": "2a82821",
+      "sha": "2a82821ec5970691199e1ffc6a49ac31f311ab59",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="070df27"
+VERSION="2a82821"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `070df27` → `2a82821` | [`070df27`](https://github.com/excalidraw/excalidraw/commit/070df27e4d18cdc9265c9a9692089fe90b6019da) → [`2a82821`](https://github.com/excalidraw/excalidraw/commit/2a82821ec5970691199e1ffc6a49ac31f311ab59) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): tweak freedraw settings and tablet UI/UX (#11551) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-06-24T22:59:10+08:00Z |
| **Changed** | 8 files, +116/-36 |

📝 Recent Commits

- [`2a82821e`](https://github.com/excalidraw/excalidraw/commit/2a82821e) fix(editor): tweak freedraw settings and tablet UI/UX (#11551)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/070df27...2a82821)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
