### PR TITLE
update(apps/excalidraw): update dev version to 20f694d

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "2a82821",
-      "sha": "2a82821ec5970691199e1ffc6a49ac31f311ab59",
+      "version": "20f694d",
+      "sha": "20f694d110d1e9048a7037ce84a82eb50d84e9dd",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="2a82821"
+VERSION="20f694d"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `2a82821` → `20f694d` | [`2a82821`](https://github.com/excalidraw/excalidraw/commit/2a82821ec5970691199e1ffc6a49ac31f311ab59) → [`20f694d`](https://github.com/excalidraw/excalidraw/commit/20f694d110d1e9048a7037ce84a82eb50d84e9dd) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): prevent freeze from extremely large line elements (#11556) |
| **Author** | minato32 &lt;77087663+minato32@users.noreply.github.com&gt; |
| **Date** | 2026-06-26T02:06:02+08:00Z |
| **Changed** | 2 files, +83/-33 |

📝 Recent Commits

- [`20f694d1`](https://github.com/excalidraw/excalidraw/commit/20f694d1) fix(editor): prevent freeze from extremely large line elements (#11556)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/2a82821...20f694d)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
