### PR TITLE
update(apps/excalidraw): update dev version to 4ce70b8

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "c070c8f",
-      "sha": "c070c8ffa62c4c88d48f33fd18a7a40d55bb808a",
+      "version": "4ce70b8",
+      "sha": "4ce70b815eccbe684866f83d2dcbcba8fc8a97a6",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="c070c8f"
+VERSION="4ce70b8"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `c070c8f` → `4ce70b8` | [`c070c8f`](https://github.com/excalidraw/excalidraw/commit/c070c8ffa62c4c88d48f33fd18a7a40d55bb808a) → [`4ce70b8`](https://github.com/excalidraw/excalidraw/commit/4ce70b815eccbe684866f83d2dcbcba8fc8a97a6) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): ensure canvas is cleared when background color is invalid to prevent ghosting (#11458) |
| **Author** | Dany Valverde Caldas &lt;dvalverd@mail.ccsf.edu&gt; |
| **Date** | 2026-06-27T04:59:17+08:00Z |
| **Changed** | 3 files, +122/-15 |

📝 Recent Commits

- [`4ce70b81`](https://github.com/excalidraw/excalidraw/commit/4ce70b81) fix(editor): ensure canvas is cleared when background color is invalid to prevent ghosting (#11458)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/c070c8f...4ce70b8)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
