### PR TITLE
update(apps/readest): update latest version to 0.11.16, update test version to 0.11.16

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.12",
-      "sha": "54d54791b0873d29f5b5850a46340aa3a74cb51b",
+      "version": "0.11.16",
+      "sha": "5358d85c0ba89bc440a5b9469b9932fcc69e318c",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.12",
-      "sha": "54d54791b0873d29f5b5850a46340aa3a74cb51b",
+      "version": "0.11.16",
+      "sha": "5358d85c0ba89bc440a5b9469b9932fcc69e318c",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.12"
+VERSION="v0.11.16"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.12"
+VERSION="v0.11.16"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.12` → `0.11.16` | [`54d5479`](https://github.com/readest/readest/commit/54d54791b0873d29f5b5850a46340aa3a74cb51b) → [`5358d85`](https://github.com/readest/readest/commit/5358d85c0ba89bc440a5b9469b9932fcc69e318c) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.12` → `0.11.16` | [`54d5479`](https://github.com/readest/readest/commit/54d54791b0873d29f5b5850a46340aa3a74cb51b) → [`5358d85`](https://github.com/readest/readest/commit/5358d85c0ba89bc440a5b9469b9932fcc69e318c) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.16 (#4847) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-29T02:50:30+08:00Z |
| **Changed** | 575 files, +33166/-4713 |

📝 Recent Commits

- [`5358d85c`](https://github.com/readest/readest/commit/5358d85c) release: version 0.11.16 (#4847)
- [`ea991066`](https://github.com/readest/readest/commit/ea991066) fix(sync): silence third-party cloud-sync error toasts (#4845)
- [`70bad93e`](https://github.com/readest/readest/commit/70bad93e) feat(reader): select word on double-click and run instant action or toolbar (#4846)
- [`eaf307e7`](https://github.com/readest/readest/commit/eaf307e7) fix(translate): align RTL translated text to the start (#4844)
- [`b87cbfa2`](https://github.com/readest/readest/commit/b87cbfa2) feat(sync): Google Drive on web via full-page redirect OAuth (#4843)
- [`7da41a65`](https://github.com/readest/readest/commit/7da41a65) feat(widget): add mobile home-screen reading widgets (#1602) (#4842)
- [`7972de19`](https://github.com/readest/readest/commit/7972de19) fix(eink): render Customize Toolbar preview as bordered surface, not black bar (#4839) (#4841)
- [`5f44c955`](https://github.com/readest/readest/commit/5f44c955) feat(sync): library-scoped auto-sync for third-party cloud (WebDAV / Drive) (#4835)
- [`ae03be96`](https://github.com/readest/readest/commit/ae03be96) chore(agent): update agent memories (#4833)
- [`69599e2b`](https://github.com/readest/readest/commit/69599e2b) fix(reader): render code operators literally instead of as ligatures (#4832)

[🔗 View full comparison](https://github.com/readest/readest/compare/54d5479...5358d85)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.16 (#4847) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-29T02:50:30+08:00Z |
| **Changed** | 575 files, +33166/-4713 |

📝 Recent Commits

- [`5358d85c`](https://github.com/readest/readest/commit/5358d85c) release: version 0.11.16 (#4847)
- [`ea991066`](https://github.com/readest/readest/commit/ea991066) fix(sync): silence third-party cloud-sync error toasts (#4845)
- [`70bad93e`](https://github.com/readest/readest/commit/70bad93e) feat(reader): select word on double-click and run instant action or toolbar (#4846)
- [`eaf307e7`](https://github.com/readest/readest/commit/eaf307e7) fix(translate): align RTL translated text to the start (#4844)
- [`b87cbfa2`](https://github.com/readest/readest/commit/b87cbfa2) feat(sync): Google Drive on web via full-page redirect OAuth (#4843)
- [`7da41a65`](https://github.com/readest/readest/commit/7da41a65) feat(widget): add mobile home-screen reading widgets (#1602) (#4842)
- [`7972de19`](https://github.com/readest/readest/commit/7972de19) fix(eink): render Customize Toolbar preview as bordered surface, not black bar (#4839) (#4841)
- [`5f44c955`](https://github.com/readest/readest/commit/5f44c955) feat(sync): library-scoped auto-sync for third-party cloud (WebDAV / Drive) (#4835)
- [`ae03be96`](https://github.com/readest/readest/commit/ae03be96) chore(agent): update agent memories (#4833)
- [`69599e2b`](https://github.com/readest/readest/commit/69599e2b) fix(reader): render code operators literally instead of as ligatures (#4832)

[🔗 View full comparison](https://github.com/readest/readest/compare/54d5479...5358d85)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
