### PR TITLE
update(apps/readest): update latest version to 0.11.17, update test version to 0.11.17

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.16",
-      "sha": "5358d85c0ba89bc440a5b9469b9932fcc69e318c",
+      "version": "0.11.17",
+      "sha": "01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.16",
-      "sha": "5358d85c0ba89bc440a5b9469b9932fcc69e318c",
+      "version": "0.11.17",
+      "sha": "01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.16"
+VERSION="v0.11.17"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.16"
+VERSION="v0.11.17"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.16` → `0.11.17` | [`5358d85`](https://github.com/readest/readest/commit/5358d85c0ba89bc440a5b9469b9932fcc69e318c) → [`01bc015`](https://github.com/readest/readest/commit/01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.16` → `0.11.17` | [`5358d85`](https://github.com/readest/readest/commit/5358d85c0ba89bc440a5b9469b9932fcc69e318c) → [`01bc015`](https://github.com/readest/readest/commit/01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.17 (hotfix for an Android crash) (#4852) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-29T10:21:28+08:00Z |
| **Changed** | 10 files, +109/-13 |

📝 Recent Commits

- [`01bc0159`](https://github.com/readest/readest/commit/01bc0159) release: version 0.11.17 (hotfix for an Android crash) (#4852)
- [`781a2979`](https://github.com/readest/readest/commit/781a2979) ci(release): attest release and nightly build artifacts (#4851)
- [`a23427cc`](https://github.com/readest/readest/commit/a23427cc) fix(widget): avoid recycling aliased source bitmap for 2:3 covers (#4850)

[🔗 View full comparison](https://github.com/readest/readest/compare/5358d85...01bc015)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.17 (hotfix for an Android crash) (#4852) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-06-29T10:21:28+08:00Z |
| **Changed** | 10 files, +109/-13 |

📝 Recent Commits

- [`01bc0159`](https://github.com/readest/readest/commit/01bc0159) release: version 0.11.17 (hotfix for an Android crash) (#4852)
- [`781a2979`](https://github.com/readest/readest/commit/781a2979) ci(release): attest release and nightly build artifacts (#4851)
- [`a23427cc`](https://github.com/readest/readest/commit/a23427cc) fix(widget): avoid recycling aliased source bitmap for 2:3 covers (#4850)

[🔗 View full comparison](https://github.com/readest/readest/compare/5358d85...01bc015)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
