### PR TITLE
update(apps/excalidraw): update dev version to cce5001

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "4ce70b8",
-      "sha": "4ce70b815eccbe684866f83d2dcbcba8fc8a97a6",
+      "version": "cce5001",
+      "sha": "cce5001aaafe0286855984cf1b4e154b6ce86754",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="4ce70b8"
+VERSION="cce5001"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `4ce70b8` → `cce5001` | [`4ce70b8`](https://github.com/excalidraw/excalidraw/commit/4ce70b815eccbe684866f83d2dcbcba8fc8a97a6) → [`cce5001`](https://github.com/excalidraw/excalidraw/commit/cce5001aaafe0286855984cf1b4e154b6ce86754) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): keep eraser shortcut consistent with tool switch rules (#11571) |
| **Author** | Anvi &lt;107345013+anviik@users.noreply.github.com&gt; |
| **Date** | 2026-06-29T16:04:08+08:00Z |
| **Changed** | 2 files, +47/-1 |

📝 Recent Commits

- [`cce5001a`](https://github.com/excalidraw/excalidraw/commit/cce5001a) fix(editor): keep eraser shortcut consistent with tool switch rules (#11571)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/4ce70b8...cce5001)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
