### PR TITLE
update(base/vscode): update latest version to 1.127.0, update stable version to 1.127.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.126.0
+ARG VERSION=1.127.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.126.0 -> 1.126.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.127.0 -> 1.127.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.126.0
+ARG VERSION=1.127.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.126.0 -> 1.126.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.127.0 -> 1.127.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.126.0",
-      "sha": "7e7950df89d055b5a378379db9ee14290772148a",
+      "version": "1.127.0",
+      "sha": "a22d00300655c17490ce63dffc28bcdcedcd82c4",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.126.0",
-      "sha": "7e7950df89d055b5a378379db9ee14290772148a",
+      "version": "1.127.0",
+      "sha": "a22d00300655c17490ce63dffc28bcdcedcd82c4",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.126.0` → `1.127.0` | [`7e7950d`](https://github.com/microsoft/vscode/commit/7e7950df89d055b5a378379db9ee14290772148a) → [`a22d003`](https://github.com/microsoft/vscode/commit/a22d00300655c17490ce63dffc28bcdcedcd82c4) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.126.0` → `1.127.0` | [`7e7950d`](https://github.com/microsoft/vscode/commit/7e7950df89d055b5a378379db9ee14290772148a) → [`a22d003`](https://github.com/microsoft/vscode/commit/a22d00300655c17490ce63dffc28bcdcedcd82c4) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | AgentHost - restore changesets when reloading the window (#323512) |
| **Author** | Ladislau Szomoru &lt;3372902+lszomoru@users.noreply.github.com&gt; |
| **Date** | 2026-06-30T19:53:00+08:00Z |
| **Changed** | 1013 files, +79555/-16316 |

📝 Recent Commits

- [`a22d0030065`](https://github.com/microsoft/vscode/commit/a22d0030065) AgentHost - restore changesets when reloading the window (#323512)
- [`4fe60c8b1cd`](https://github.com/microsoft/vscode/commit/4fe60c8b1cd) Skip for now the sanity checks (#323684)
- [`8680b3b6cf9`](https://github.com/microsoft/vscode/commit/8680b3b6cf9) [cherry-pick] Rename capi-oauth secret (#323669)
- [`62661f6b9ed`](https://github.com/microsoft/vscode/commit/62661f6b9ed) [cherry-pick] sessions: fix sessions picker closing immediately on Ctrl+R release (#323614)
- [`940ebc8514d`](https://github.com/microsoft/vscode/commit/940ebc8514d) [cherry-pick] Record proxy type (#323591)
- [`0a04e1997f0`](https://github.com/microsoft/vscode/commit/0a04e1997f0) [cherry-pick] Disable semantic_search on BYOK/custom endpoints (#323610)
- [`9a1516e35d6`](https://github.com/microsoft/vscode/commit/9a1516e35d6) [cherry-pick] Browser: fix url bar taking back focus after navigating on a new tab (#323583)
- [`50bbeb00a6a`](https://github.com/microsoft/vscode/commit/50bbeb00a6a) Merge pull request #323587 from microsoft/connor/release-1.127-agent-tool-stalls
- [`6649520e315`](https://github.com/microsoft/vscode/commit/6649520e315) [cherry-pick] sessions: gate Copilot CLI/Claude agent-host preferences on chat.agentHost.enabled (#323571)
- [`ae561b7ebde`](https://github.com/microsoft/vscode/commit/ae561b7ebde) [cherry-pick] sessions: persist closed chats across session switch (#323436)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/7e7950d...a22d003)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | AgentHost - restore changesets when reloading the window (#323512) |
| **Author** | Ladislau Szomoru &lt;3372902+lszomoru@users.noreply.github.com&gt; |
| **Date** | 2026-06-30T19:53:00+08:00Z |
| **Changed** | 1013 files, +79555/-16316 |

📝 Recent Commits

- [`a22d0030065`](https://github.com/microsoft/vscode/commit/a22d0030065) AgentHost - restore changesets when reloading the window (#323512)
- [`4fe60c8b1cd`](https://github.com/microsoft/vscode/commit/4fe60c8b1cd) Skip for now the sanity checks (#323684)
- [`8680b3b6cf9`](https://github.com/microsoft/vscode/commit/8680b3b6cf9) [cherry-pick] Rename capi-oauth secret (#323669)
- [`62661f6b9ed`](https://github.com/microsoft/vscode/commit/62661f6b9ed) [cherry-pick] sessions: fix sessions picker closing immediately on Ctrl+R release (#323614)
- [`940ebc8514d`](https://github.com/microsoft/vscode/commit/940ebc8514d) [cherry-pick] Record proxy type (#323591)
- [`0a04e1997f0`](https://github.com/microsoft/vscode/commit/0a04e1997f0) [cherry-pick] Disable semantic_search on BYOK/custom endpoints (#323610)
- [`9a1516e35d6`](https://github.com/microsoft/vscode/commit/9a1516e35d6) [cherry-pick] Browser: fix url bar taking back focus after navigating on a new tab (#323583)
- [`50bbeb00a6a`](https://github.com/microsoft/vscode/commit/50bbeb00a6a) Merge pull request #323587 from microsoft/connor/release-1.127-agent-tool-stalls
- [`6649520e315`](https://github.com/microsoft/vscode/commit/6649520e315) [cherry-pick] sessions: gate Copilot CLI/Claude agent-host preferences on chat.agentHost.enabled (#323571)
- [`ae561b7ebde`](https://github.com/microsoft/vscode/commit/ae561b7ebde) [cherry-pick] sessions: persist closed chats across session switch (#323436)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/7e7950d...a22d003)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
