### PR TITLE
update(apps/excalidraw): update dev version to 51ca8ab

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "cce5001",
-      "sha": "cce5001aaafe0286855984cf1b4e154b6ce86754",
+      "version": "51ca8ab",
+      "sha": "51ca8abde450e44f8f0db1b2708e0408915c7ab1",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="cce5001"
+VERSION="51ca8ab"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `cce5001` → `51ca8ab` | [`cce5001`](https://github.com/excalidraw/excalidraw/commit/cce5001aaafe0286855984cf1b4e154b6ce86754) → [`51ca8ab`](https://github.com/excalidraw/excalidraw/commit/51ca8abde450e44f8f0db1b2708e0408915c7ab1) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(packages/excalidraw): viewport locking (#11554) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-07-04T04:57:47+08:00Z |
| **Changed** | 28 files, +2774/-713 |

📝 Recent Commits

- [`51ca8abd`](https://github.com/excalidraw/excalidraw/commit/51ca8abd) feat(packages/excalidraw): viewport locking (#11554)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/cce5001...51ca8ab)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
