### PR TITLE
update(apps/excalidraw): update dev version to aaa14e9

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "9357f98",
-      "sha": "9357f98a9b6c4f8af3ada6ccce38e54330f2627c",
+      "version": "aaa14e9",
+      "sha": "aaa14e9df6ba85a19baa52e8378d7b54f9a542f3",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="9357f98"
+VERSION="aaa14e9"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `9357f98` → `aaa14e9` | [`9357f98`](https://github.com/excalidraw/excalidraw/commit/9357f98a9b6c4f8af3ada6ccce38e54330f2627c) → [`aaa14e9`](https://github.com/excalidraw/excalidraw/commit/aaa14e9df6ba85a19baa52e8378d7b54f9a542f3) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(editor): show cursor hint when switching arrow types (#11608) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-07-07T18:55:32+08:00Z |
| **Changed** | 5 files, +478/-8 |

📝 Recent Commits

- [`aaa14e9d`](https://github.com/excalidraw/excalidraw/commit/aaa14e9d) feat(editor): show cursor hint when switching arrow types (#11608)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/9357f98...aaa14e9)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
