### PR TITLE
update(apps/readest): update latest version to 0.11.18, update test version to 0.11.18

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.17",
-      "sha": "01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a",
+      "version": "0.11.18",
+      "sha": "4af203755d807ae317c9ffe4922f5f1e7989a66b",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.17",
-      "sha": "01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a",
+      "version": "0.11.18",
+      "sha": "4af203755d807ae317c9ffe4922f5f1e7989a66b",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.17"
+VERSION="v0.11.18"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.17"
+VERSION="v0.11.18"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.17` → `0.11.18` | [`01bc015`](https://github.com/readest/readest/commit/01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a) → [`4af2037`](https://github.com/readest/readest/commit/4af203755d807ae317c9ffe4922f5f1e7989a66b) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.17` → `0.11.18` | [`01bc015`](https://github.com/readest/readest/commit/01bc0159853ad5470cf9a40ae6fa1d7d0dad1d2a) → [`4af2037`](https://github.com/readest/readest/commit/4af203755d807ae317c9ffe4922f5f1e7989a66b) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.18 (#5003) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-07-08T02:17:35+08:00Z |
| **Changed** | 427 files, +34025/-4248 |

📝 Recent Commits

- [`4af20375`](https://github.com/readest/readest/commit/4af20375) release: version 0.11.18 (#5003)
- [`883dae36`](https://github.com/readest/readest/commit/883dae36) fix(opds): auth negotiation and auto-download fixes for self-hosted catalogs (#5002)
- [`0c24aad6`](https://github.com/readest/readest/commit/0c24aad6) fix(reader): let page margins shrink into the safe-area inset (#4761) (#5001)
- [`a8d34112`](https://github.com/readest/readest/commit/a8d34112) fix(reader): gate captured slide/curl turn on scrollLocked like push (#5000)
- [`f8ad47a4`](https://github.com/readest/readest/commit/f8ad47a4) feat(reader): Auto Scroll reading mode for scrolled flow (#4998) (#4999)
- [`17de9357`](https://github.com/readest/readest/commit/17de9357) feat(reader): redesign the TTS control as a mini player with an expandable player sheet (#4996)
- [`ab628fe2`](https://github.com/readest/readest/commit/ab628fe2) fix(android): background TTS media controls + lock-screen scrubber/seek + Edge click fix (#4994)
- [`3ce5a5c8`](https://github.com/readest/readest/commit/3ce5a5c8) fix(reader): center the lone PDF page in portrait auto-spread (#4984) (#4992)
- [`56abcb4a`](https://github.com/readest/readest/commit/56abcb4a) feat(sync): S3-compatible cloud sync provider (#4990)
- [`600d69fa`](https://github.com/readest/readest/commit/600d69fa) fix(reader): gate route View Transitions on API support (READEST-9) (#4989)

[🔗 View full comparison](https://github.com/readest/readest/compare/01bc015...4af2037)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.18 (#5003) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-07-08T02:17:35+08:00Z |
| **Changed** | 427 files, +34025/-4248 |

📝 Recent Commits

- [`4af20375`](https://github.com/readest/readest/commit/4af20375) release: version 0.11.18 (#5003)
- [`883dae36`](https://github.com/readest/readest/commit/883dae36) fix(opds): auth negotiation and auto-download fixes for self-hosted catalogs (#5002)
- [`0c24aad6`](https://github.com/readest/readest/commit/0c24aad6) fix(reader): let page margins shrink into the safe-area inset (#4761) (#5001)
- [`a8d34112`](https://github.com/readest/readest/commit/a8d34112) fix(reader): gate captured slide/curl turn on scrollLocked like push (#5000)
- [`f8ad47a4`](https://github.com/readest/readest/commit/f8ad47a4) feat(reader): Auto Scroll reading mode for scrolled flow (#4998) (#4999)
- [`17de9357`](https://github.com/readest/readest/commit/17de9357) feat(reader): redesign the TTS control as a mini player with an expandable player sheet (#4996)
- [`ab628fe2`](https://github.com/readest/readest/commit/ab628fe2) fix(android): background TTS media controls + lock-screen scrubber/seek + Edge click fix (#4994)
- [`3ce5a5c8`](https://github.com/readest/readest/commit/3ce5a5c8) fix(reader): center the lone PDF page in portrait auto-spread (#4984) (#4992)
- [`56abcb4a`](https://github.com/readest/readest/commit/56abcb4a) feat(sync): S3-compatible cloud sync provider (#4990)
- [`600d69fa`](https://github.com/readest/readest/commit/600d69fa) fix(reader): gate route View Transitions on API support (READEST-9) (#4989)

[🔗 View full comparison](https://github.com/readest/readest/compare/01bc015...4af2037)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
