### PR TITLE
update(apps/excalidraw): update dev version to ba0387d

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "dd8296a",
-      "sha": "dd8296af1802d4920a645591e0de88b9272745fa",
+      "version": "ba0387d",
+      "sha": "ba0387d186b361d8d9a2390f396cb17527073442",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="dd8296a"
+VERSION="ba0387d"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `dd8296a` → `ba0387d` | [`dd8296a`](https://github.com/excalidraw/excalidraw/commit/dd8296af1802d4920a645591e0de88b9272745fa) → [`ba0387d`](https://github.com/excalidraw/excalidraw/commit/ba0387d186b361d8d9a2390f396cb17527073442) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | chore(editor): Update translations from Crowdin (#10731) |
| **Author** | Excalidraw Bot &lt;77840495+excalibot@users.noreply.github.com&gt; |
| **Date** | 2026-07-08T04:37:30+08:00Z |
| **Changed** | 59 files, +1756/-632 |

📝 Recent Commits

- [`ba0387d1`](https://github.com/excalidraw/excalidraw/commit/ba0387d1) chore(editor): Update translations from Crowdin (#10731)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/dd8296a...ba0387d)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
