### PR TITLE
update(base/vscode): update latest version to 1.128.0, update stable version to 1.128.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.127.0
+ARG VERSION=1.128.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.127.0 -> 1.127.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.0 -> 1.128.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.127.0
+ARG VERSION=1.128.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.127.0 -> 1.127.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.0 -> 1.128.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.127.0",
-      "sha": "a22d00300655c17490ce63dffc28bcdcedcd82c4",
+      "version": "1.128.0",
+      "sha": "fc3def6774c76082adf699d366f31a557ce5573f",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.127.0",
-      "sha": "a22d00300655c17490ce63dffc28bcdcedcd82c4",
+      "version": "1.128.0",
+      "sha": "fc3def6774c76082adf699d366f31a557ce5573f",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.127.0` → `1.128.0` | [`a22d003`](https://github.com/microsoft/vscode/commit/a22d00300655c17490ce63dffc28bcdcedcd82c4) → [`fc3def6`](https://github.com/microsoft/vscode/commit/fc3def6774c76082adf699d366f31a557ce5573f) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.127.0` → `1.128.0` | [`a22d003`](https://github.com/microsoft/vscode/commit/a22d00300655c17490ce63dffc28bcdcedcd82c4) → [`fc3def6`](https://github.com/microsoft/vscode/commit/fc3def6774c76082adf699d366f31a557ce5573f) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | [Cherry-pick] Remove last-used session type and agent logic (#323484) (#324826) |
| **Author** | Ben Villalobos &lt;bevillal@microsoft.com&gt; |
| **Date** | 2026-07-08T06:14:24+08:00Z |
| **Changed** | 902 files, +66891/-12235 |

📝 Recent Commits

- [`fc3def6774c`](https://github.com/microsoft/vscode/commit/fc3def6774c) [Cherry-pick] Remove last-used session type and agent logic (#323484) (#324826)
- [`2eb70532465`](https://github.com/microsoft/vscode/commit/2eb70532465) chat: revert &#39;keep sticky scroll with pending messages&#39; (1.128) (#324818)
- [`7a8049eb2d2`](https://github.com/microsoft/vscode/commit/7a8049eb2d2) Merge pull request #324735 from microsoft/revert-placeholder-color-1.128
- [`93e30b9cc9f`](https://github.com/microsoft/vscode/commit/93e30b9cc9f) Revert &quot;a11y: Update placeholder foreground colors in input fields for dark a…&quot;
- [`7f5f76274d9`](https://github.com/microsoft/vscode/commit/7f5f76274d9) Include request UUID in completion feedback (fix empty telemetry section)#324595 (#324703)
- [`cc31356f64f`](https://github.com/microsoft/vscode/commit/cc31356f64f) [cherry-pick] Cache assignment filter results per filter in the assignment service (#324711)
- [`4bfc62aa603`](https://github.com/microsoft/vscode/commit/4bfc62aa603) [cherry-pick] Include request UUID in completion feedback (fix empty telemetry section) (#324708)
- [`fd8f728cf1a`](https://github.com/microsoft/vscode/commit/fd8f728cf1a) Only show completion feedback command for paid users (#324586)
- [`bff87363854`](https://github.com/microsoft/vscode/commit/bff87363854) Preserve explicit local chat editor sessions (#324669)
- [`1e3f4e4e252`](https://github.com/microsoft/vscode/commit/1e3f4e4e252) [release/1.128] Update GPT-5.6 model family detection (#324658)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/a22d003...fc3def6)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | [Cherry-pick] Remove last-used session type and agent logic (#323484) (#324826) |
| **Author** | Ben Villalobos &lt;bevillal@microsoft.com&gt; |
| **Date** | 2026-07-08T06:14:24+08:00Z |
| **Changed** | 902 files, +66891/-12235 |

📝 Recent Commits

- [`fc3def6774c`](https://github.com/microsoft/vscode/commit/fc3def6774c) [Cherry-pick] Remove last-used session type and agent logic (#323484) (#324826)
- [`2eb70532465`](https://github.com/microsoft/vscode/commit/2eb70532465) chat: revert &#39;keep sticky scroll with pending messages&#39; (1.128) (#324818)
- [`7a8049eb2d2`](https://github.com/microsoft/vscode/commit/7a8049eb2d2) Merge pull request #324735 from microsoft/revert-placeholder-color-1.128
- [`93e30b9cc9f`](https://github.com/microsoft/vscode/commit/93e30b9cc9f) Revert &quot;a11y: Update placeholder foreground colors in input fields for dark a…&quot;
- [`7f5f76274d9`](https://github.com/microsoft/vscode/commit/7f5f76274d9) Include request UUID in completion feedback (fix empty telemetry section)#324595 (#324703)
- [`cc31356f64f`](https://github.com/microsoft/vscode/commit/cc31356f64f) [cherry-pick] Cache assignment filter results per filter in the assignment service (#324711)
- [`4bfc62aa603`](https://github.com/microsoft/vscode/commit/4bfc62aa603) [cherry-pick] Include request UUID in completion feedback (fix empty telemetry section) (#324708)
- [`fd8f728cf1a`](https://github.com/microsoft/vscode/commit/fd8f728cf1a) Only show completion feedback command for paid users (#324586)
- [`bff87363854`](https://github.com/microsoft/vscode/commit/bff87363854) Preserve explicit local chat editor sessions (#324669)
- [`1e3f4e4e252`](https://github.com/microsoft/vscode/commit/1e3f4e4e252) [release/1.128] Update GPT-5.6 model family detection (#324658)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/a22d003...fc3def6)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
