### PR TITLE
update(apps/excalidraw): update dev version to 8462bb8

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "ba0387d",
-      "sha": "ba0387d186b361d8d9a2390f396cb17527073442",
+      "version": "8462bb8",
+      "sha": "8462bb81fb489630330bf5824f9a404b016ce178",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="ba0387d"
+VERSION="8462bb8"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `ba0387d` → `8462bb8` | [`ba0387d`](https://github.com/excalidraw/excalidraw/commit/ba0387d186b361d8d9a2390f396cb17527073442) → [`8462bb8`](https://github.com/excalidraw/excalidraw/commit/8462bb81fb489630330bf5824f9a404b016ce178) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): Very small bindables can blow up fixedPoint -&gt; position ratio (#11607) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-07-08T18:20:30+08:00Z |
| **Changed** | 2 files, +107/-8 |

📝 Recent Commits

- [`8462bb81`](https://github.com/excalidraw/excalidraw/commit/8462bb81) fix(editor): Very small bindables can blow up fixedPoint -&gt; position ratio (#11607)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/ba0387d...8462bb8)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
