### PR TITLE
update(apps/excalidraw): update dev version to 063e025

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "ba0387d",
-      "sha": "ba0387d186b361d8d9a2390f396cb17527073442",
+      "version": "063e025",
+      "sha": "063e0256f5f8654aec1c88a2822caedcd3bab4f3",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="ba0387d"
+VERSION="063e025"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `ba0387d` → `063e025` | [`ba0387d`](https://github.com/excalidraw/excalidraw/commit/ba0387d186b361d8d9a2390f396cb17527073442) → [`063e025`](https://github.com/excalidraw/excalidraw/commit/063e0256f5f8654aec1c88a2822caedcd3bab4f3) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): arrow label rendering fixes and perf improvements (#11637) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-07-09T05:13:01+08:00Z |
| **Changed** | 4 files, +272/-174 |

📝 Recent Commits

- [`063e0256`](https://github.com/excalidraw/excalidraw/commit/063e0256) fix(editor): arrow label rendering fixes and perf improvements (#11637)
- [`fbff8324`](https://github.com/excalidraw/excalidraw/commit/fbff8324) fix(editor): Fix binding.test.ts type mismatch (#11633)
- [`8462bb81`](https://github.com/excalidraw/excalidraw/commit/8462bb81) fix(editor): Very small bindables can blow up fixedPoint -&gt; position ratio (#11607)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/ba0387d...063e025)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
