### PR TITLE
update(apps/excalidraw): update dev version to 3b9e1c0

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "adf9631",
-      "sha": "adf963199762e5675811f3fbae779625ca7d0ba3",
+      "version": "3b9e1c0",
+      "sha": "3b9e1c07f5d32ee11c327dc006f2050ffc6eea19",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="adf9631"
+VERSION="3b9e1c0"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `adf9631` → `3b9e1c0` | [`adf9631`](https://github.com/excalidraw/excalidraw/commit/adf963199762e5675811f3fbae779625ca7d0ba3) → [`3b9e1c0`](https://github.com/excalidraw/excalidraw/commit/3b9e1c07f5d32ee11c327dc006f2050ffc6eea19) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): Dragged arrow endpoint ignore grid and angle locks (#10972) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-07-10T17:19:44+08:00Z |
| **Changed** | 9 files, +318/-32 |

📝 Recent Commits

- [`3b9e1c07`](https://github.com/excalidraw/excalidraw/commit/3b9e1c07) fix(editor): Dragged arrow endpoint ignore grid and angle locks (#10972)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/adf9631...3b9e1c0)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
