### PR TITLE
update(apps/excalidraw): update dev version to ed7c0c1

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "3b9e1c0",
-      "sha": "3b9e1c07f5d32ee11c327dc006f2050ffc6eea19",
+      "version": "ed7c0c1",
+      "sha": "ed7c0c1d7d5510c961f09f6904c5c317b665d443",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="3b9e1c0"
+VERSION="ed7c0c1"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `3b9e1c0` → `ed7c0c1` | [`3b9e1c0`](https://github.com/excalidraw/excalidraw/commit/3b9e1c07f5d32ee11c327dc006f2050ffc6eea19) → [`ed7c0c1`](https://github.com/excalidraw/excalidraw/commit/ed7c0c1d7d5510c961f09f6904c5c317b665d443) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | chore(editor): Refactor Actions for clarity (#11632) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-07-11T23:22:35+08:00Z |
| **Changed** | 2 files, +342/-356 |

📝 Recent Commits

- [`ed7c0c1d`](https://github.com/excalidraw/excalidraw/commit/ed7c0c1d) chore(editor): Refactor Actions for clarity (#11632)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/3b9e1c0...ed7c0c1)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
