### PR TITLE
update(apps/dashboard-icons): update latest version to ee0e0f8

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "00c43aa",
-      "sha": "00c43aa6857e2905b1d59bfceddfca7bc145f44a",
+      "version": "ee0e0f8",
+      "sha": "ee0e0f81d610dc93479f6796ce80ddfc2171fd20",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="00c43aa"
+VERSION="ee0e0f8"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `00c43aa` → `ee0e0f8` | [`00c43aa`](https://github.com/homarr-labs/dashboard-icons/commit/00c43aa6857e2905b1d59bfceddfca7bc145f44a) → [`ee0e0f8`](https://github.com/homarr-labs/dashboard-icons/commit/ee0e0f81d610dc93479f6796ce80ddfc2171fd20) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | Merge pull request #2883 from homarr-labs/blacksmith-migration-00c43aa |
| **Author** | Thomas &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-07-12T01:25:10+08:00Z |
| **Changed** | 2 files, +5/-5 |

📝 Recent Commits

- [`ee0e0f81`](https://github.com/homarr-labs/dashboard-icons/commit/ee0e0f81) Merge pull request #2883 from homarr-labs/blacksmith-migration-00c43aa
- [`ee5e721f`](https://github.com/homarr-labs/dashboard-icons/commit/ee5e721f) Migrate workflows to Blacksmith

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/00c43aa...ee0e0f8)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
