### PR TITLE
update(apps/excalidraw): update dev version to d331bb4

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "339d3c3",
-      "sha": "339d3c373314d6b6bd0093949215ca00c1fb0c89",
+      "version": "d331bb4",
+      "sha": "d331bb49fce8975819bae1c55c7a43bcd778a8af",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="339d3c3"
+VERSION="d331bb4"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `339d3c3` → `d331bb4` | [`339d3c3`](https://github.com/excalidraw/excalidraw/commit/339d3c373314d6b6bd0093949215ca00c1fb0c89) → [`d331bb4`](https://github.com/excalidraw/excalidraw/commit/d331bb49fce8975819bae1c55c7a43bcd778a8af) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): avoid overlap of flowchart children (#11532) |
| **Author** | minato32 &lt;77087663+minato32@users.noreply.github.com&gt; |
| **Date** | 2026-07-13T22:52:19+08:00Z |
| **Changed** | 6 files, +828/-484 |

📝 Recent Commits

- [`d331bb49`](https://github.com/excalidraw/excalidraw/commit/d331bb49) fix(editor): avoid overlap of flowchart children (#11532)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/339d3c3...d331bb4)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
