### PR TITLE
update(apps/excalidraw): update dev version to 5776e1c

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "e9c856d",
-      "sha": "e9c856d262a14c12bd0bdc3f4ac55c7a86a71577",
+      "version": "5776e1c",
+      "sha": "5776e1cc66842ca229c79fbbf3d2ccf208c24ab0",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="e9c856d"
+VERSION="5776e1c"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `e9c856d` → `5776e1c` | [`e9c856d`](https://github.com/excalidraw/excalidraw/commit/e9c856d262a14c12bd0bdc3f4ac55c7a86a71577) → [`5776e1c`](https://github.com/excalidraw/excalidraw/commit/5776e1cc66842ca229c79fbbf3d2ccf208c24ab0) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): should not select deleted bound text (#11660) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-07-14T19:19:19+08:00Z |
| **Changed** | 1 files, +1/-0 |

📝 Recent Commits

- [`5776e1cc`](https://github.com/excalidraw/excalidraw/commit/5776e1cc) fix(editor): should not select deleted bound text (#11660)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/e9c856d...5776e1c)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
