### PR TITLE
update(base/vscode): update latest version to 1.128.1, update stable version to 1.128.1

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.128.0
+ARG VERSION=1.128.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.0 -> 1.128.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.1 -> 1.128.1.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.128.0
+ARG VERSION=1.128.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.0 -> 1.128.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.1 -> 1.128.1.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.128.0",
-      "sha": "fc3def6774c76082adf699d366f31a557ce5573f",
+      "version": "1.128.1",
+      "sha": "5264f2156cbcd7aea5fd004d29eaa10209155d66",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.128.0",
-      "sha": "fc3def6774c76082adf699d366f31a557ce5573f",
+      "version": "1.128.1",
+      "sha": "5264f2156cbcd7aea5fd004d29eaa10209155d66",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.128.0` → `1.128.1` | [`fc3def6`](https://github.com/microsoft/vscode/commit/fc3def6774c76082adf699d366f31a557ce5573f) → [`5264f21`](https://github.com/microsoft/vscode/commit/5264f2156cbcd7aea5fd004d29eaa10209155d66) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.128.0` → `1.128.1` | [`fc3def6`](https://github.com/microsoft/vscode/commit/fc3def6774c76082adf699d366f31a557ce5573f) → [`5264f21`](https://github.com/microsoft/vscode/commit/5264f2156cbcd7aea5fd004d29eaa10209155d66) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | ci: switch archive.ubuntu.com to azure.archive.ubuntu.com for snap (#74) |
| **Author** | Kyle Cutler &lt;Kyle.Cutler@microsoft.com&gt; |
| **Date** | 2026-07-14T22:19:31+08:00Z |
| **Changed** | 13 files, +122/-23 |

📝 Recent Commits

- [`5264f2156cb`](https://github.com/microsoft/vscode/commit/5264f2156cb) ci: switch archive.ubuntu.com to azure.archive.ubuntu.com for snap (#74)
- [`b6d334ffdbd`](https://github.com/microsoft/vscode/commit/b6d334ffdbd) fix persistent workbench UI performance degradation (#324986) (#73)
- [`d949774eb6c`](https://github.com/microsoft/vscode/commit/d949774eb6c) Bump version to 1.128.1 (#70)
- [`236fa7d8ea8`](https://github.com/microsoft/vscode/commit/236fa7d8ea8) fix(serve-web): reject attacker-controlled parentOrigin in webWorkerExtensionHostIframe (#69)
- [`bc2d56c6f8d`](https://github.com/microsoft/vscode/commit/bc2d56c6f8d) fix: improve rendering of mermaid blocks by using DOMParser for HTML parsing (#68)
- [`f05bcd1aa29`](https://github.com/microsoft/vscode/commit/f05bcd1aa29) Allow hidden advanced settings to respsect workspace trust (#67)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/fc3def6...5264f21)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | ci: switch archive.ubuntu.com to azure.archive.ubuntu.com for snap (#74) |
| **Author** | Kyle Cutler &lt;Kyle.Cutler@microsoft.com&gt; |
| **Date** | 2026-07-14T22:19:31+08:00Z |
| **Changed** | 13 files, +122/-23 |

📝 Recent Commits

- [`5264f2156cb`](https://github.com/microsoft/vscode/commit/5264f2156cb) ci: switch archive.ubuntu.com to azure.archive.ubuntu.com for snap (#74)
- [`b6d334ffdbd`](https://github.com/microsoft/vscode/commit/b6d334ffdbd) fix persistent workbench UI performance degradation (#324986) (#73)
- [`d949774eb6c`](https://github.com/microsoft/vscode/commit/d949774eb6c) Bump version to 1.128.1 (#70)
- [`236fa7d8ea8`](https://github.com/microsoft/vscode/commit/236fa7d8ea8) fix(serve-web): reject attacker-controlled parentOrigin in webWorkerExtensionHostIframe (#69)
- [`bc2d56c6f8d`](https://github.com/microsoft/vscode/commit/bc2d56c6f8d) fix: improve rendering of mermaid blocks by using DOMParser for HTML parsing (#68)
- [`f05bcd1aa29`](https://github.com/microsoft/vscode/commit/f05bcd1aa29) Allow hidden advanced settings to respsect workspace trust (#67)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/fc3def6...5264f21)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
