### PR TITLE
update(base/vscode): update latest version to 1.129.0, update stable version to 1.129.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.128.1
+ARG VERSION=1.129.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.1 -> 1.128.1.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.0 -> 1.129.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.128.1
+ARG VERSION=1.129.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.128.1 -> 1.128.1.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.0 -> 1.129.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.128.1",
-      "sha": "5264f2156cbcd7aea5fd004d29eaa10209155d66",
+      "version": "1.129.0",
+      "sha": "125df4672b8a6a34975303c6b0baa124e560a4f7",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.128.1",
-      "sha": "5264f2156cbcd7aea5fd004d29eaa10209155d66",
+      "version": "1.129.0",
+      "sha": "125df4672b8a6a34975303c6b0baa124e560a4f7",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.128.1` → `1.129.0` | [`5264f21`](https://github.com/microsoft/vscode/commit/5264f2156cbcd7aea5fd004d29eaa10209155d66) → [`125df46`](https://github.com/microsoft/vscode/commit/125df4672b8a6a34975303c6b0baa124e560a4f7) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.128.1` → `1.129.0` | [`5264f21`](https://github.com/microsoft/vscode/commit/5264f2156cbcd7aea5fd004d29eaa10209155d66) → [`125df46`](https://github.com/microsoft/vscode/commit/125df4672b8a6a34975303c6b0baa124e560a4f7) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | [cherry-pick] More resilient session finding (#325794) (#325874) |
| **Author** | Kyle Cutler &lt;67761731+kycutler@users.noreply.github.com&gt; |
| **Date** | 2026-07-15T08:08:44+08:00Z |
| **Changed** | 1683 files, +89325/-27163 |

📝 Recent Commits

- [`125df4672b8`](https://github.com/microsoft/vscode/commit/125df4672b8) [cherry-pick] More resilient session finding (#325794) (#325874)
- [`122091bbcef`](https://github.com/microsoft/vscode/commit/122091bbcef) [cherry-pick] Fix OOM error in CI builds (#325678) (#325877)
- [`dc8e0181283`](https://github.com/microsoft/vscode/commit/dc8e0181283) Fixes https://github.com/microsoft/vscode/issues/325779 (#325855)
- [`dec8b64ee89`](https://github.com/microsoft/vscode/commit/dec8b64ee89) don&#39;t open markdown editor in agent window by default (#325674)
- [`155b746da5f`](https://github.com/microsoft/vscode/commit/155b746da5f) MSRC Fixes (#325849)
- [`174edf23f6d`](https://github.com/microsoft/vscode/commit/174edf23f6d) [cherry-pick] ci: switch archive.ubuntu.com to azure.archive.ubuntu.com for snap (#325723)
- [`634b9158d10`](https://github.com/microsoft/vscode/commit/634b9158d10) [cherry-pick] Preserve model attribution for cached inline edits (#325718)
- [`5215a26a122`](https://github.com/microsoft/vscode/commit/5215a26a122) [cherry-pick] Only show &quot;Preparing session…&quot; during imported (migration) turn (#325687)
- [`72f41c0fcc3`](https://github.com/microsoft/vscode/commit/72f41c0fcc3) Revert &quot;Use server-backed archived state for agent host sessions (#325399)&quot; (#325637)
- [`f3725632930`](https://github.com/microsoft/vscode/commit/f3725632930) Revert &quot;Re-enable Chat Sandbox home-read smoke test by re-warming chat after restart&quot; (#325636)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/5264f21...125df46)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | [cherry-pick] More resilient session finding (#325794) (#325874) |
| **Author** | Kyle Cutler &lt;67761731+kycutler@users.noreply.github.com&gt; |
| **Date** | 2026-07-15T08:08:44+08:00Z |
| **Changed** | 1683 files, +89325/-27163 |

📝 Recent Commits

- [`125df4672b8`](https://github.com/microsoft/vscode/commit/125df4672b8) [cherry-pick] More resilient session finding (#325794) (#325874)
- [`122091bbcef`](https://github.com/microsoft/vscode/commit/122091bbcef) [cherry-pick] Fix OOM error in CI builds (#325678) (#325877)
- [`dc8e0181283`](https://github.com/microsoft/vscode/commit/dc8e0181283) Fixes https://github.com/microsoft/vscode/issues/325779 (#325855)
- [`dec8b64ee89`](https://github.com/microsoft/vscode/commit/dec8b64ee89) don&#39;t open markdown editor in agent window by default (#325674)
- [`155b746da5f`](https://github.com/microsoft/vscode/commit/155b746da5f) MSRC Fixes (#325849)
- [`174edf23f6d`](https://github.com/microsoft/vscode/commit/174edf23f6d) [cherry-pick] ci: switch archive.ubuntu.com to azure.archive.ubuntu.com for snap (#325723)
- [`634b9158d10`](https://github.com/microsoft/vscode/commit/634b9158d10) [cherry-pick] Preserve model attribution for cached inline edits (#325718)
- [`5215a26a122`](https://github.com/microsoft/vscode/commit/5215a26a122) [cherry-pick] Only show &quot;Preparing session…&quot; during imported (migration) turn (#325687)
- [`72f41c0fcc3`](https://github.com/microsoft/vscode/commit/72f41c0fcc3) Revert &quot;Use server-backed archived state for agent host sessions (#325399)&quot; (#325637)
- [`f3725632930`](https://github.com/microsoft/vscode/commit/f3725632930) Revert &quot;Re-enable Chat Sandbox home-read smoke test by re-warming chat after restart&quot; (#325636)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/5264f21...125df46)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
