### PR TITLE
update(apps/excalidraw): update dev version to 344878b

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "3747163",
-      "sha": "374716304a7ded17769aa931b27e166cdc8ca2b2",
+      "version": "344878b",
+      "sha": "344878b0b5f34daf013cc5656bd78c72dfdd61d6",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="3747163"
+VERSION="344878b"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `3747163` → `344878b` | [`3747163`](https://github.com/excalidraw/excalidraw/commit/374716304a7ded17769aa931b27e166cdc8ca2b2) → [`344878b`](https://github.com/excalidraw/excalidraw/commit/344878b0b5f34daf013cc5656bd78c72dfdd61d6) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | ci(repo): skip docs &amp; example deployments in CI (#11674) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-07-16T22:36:11+08:00Z |
| **Changed** | 4 files, +30/-0 |

📝 Recent Commits

- [`344878b0`](https://github.com/excalidraw/excalidraw/commit/344878b0) ci(repo): skip docs &amp; example deployments in CI (#11674)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/3747163...344878b)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
