### PR TITLE
update(base/vscode): update latest version to 1.129.1, update stable version to 1.129.1

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.129.0
+ARG VERSION=1.129.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.0 -> 1.129.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.1 -> 1.129.1.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.129.0
+ARG VERSION=1.129.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.0 -> 1.129.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.1 -> 1.129.1.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.129.0",
-      "sha": "125df4672b8a6a34975303c6b0baa124e560a4f7",
+      "version": "1.129.1",
+      "sha": "8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.129.0",
-      "sha": "125df4672b8a6a34975303c6b0baa124e560a4f7",
+      "version": "1.129.1",
+      "sha": "8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.129.0` → `1.129.1` | [`125df46`](https://github.com/microsoft/vscode/commit/125df4672b8a6a34975303c6b0baa124e560a4f7) → [`8a7abeb`](https://github.com/microsoft/vscode/commit/8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.129.0` → `1.129.1` | [`125df46`](https://github.com/microsoft/vscode/commit/125df4672b8a6a34975303c6b0baa124e560a4f7) → [`8a7abeb`](https://github.com/microsoft/vscode/commit/8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | fix: restore 8 KiB Node buffer pool on linux (#326334) |
| **Author** | Robo &lt;hop2deep@gmail.com&gt; |
| **Date** | 2026-07-17T23:35:09+08:00Z |
| **Changed** | 15 files, +360/-9 |

📝 Recent Commits

- [`8a7abeba6e0`](https://github.com/microsoft/vscode/commit/8a7abeba6e0) fix: restore 8 KiB Node buffer pool on linux (#326334)
- [`b86e21ea982`](https://github.com/microsoft/vscode/commit/b86e21ea982) Reland &quot;chore: update electron@42.6.0&quot; (#326277)
- [`2075dc76aa0`](https://github.com/microsoft/vscode/commit/2075dc76aa0) Bump version to 1.129.1 (#326222)
- [`6acd0b9a3b7`](https://github.com/microsoft/vscode/commit/6acd0b9a3b7) Revert &quot;chore: update electron@42.6.0 (#325428)&quot; (#326219)
- [`18284a2f5ff`](https://github.com/microsoft/vscode/commit/18284a2f5ff) Fix remote Agent Host dependency packaging (#326019) (#326075)
- [`6e3c53c9430`](https://github.com/microsoft/vscode/commit/6e3c53c9430) Merge pull request #326058 from microsoft/connor/defer-mcp-dynamic-registration-release-1.129
- [`cc2661465d8`](https://github.com/microsoft/vscode/commit/cc2661465d8) agentHost: add release MCP auth test imports
- [`d84b2adc0cf`](https://github.com/microsoft/vscode/commit/d84b2adc0cf) agentHost: defer interactive MCP client registration

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/125df46...8a7abeb)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | fix: restore 8 KiB Node buffer pool on linux (#326334) |
| **Author** | Robo &lt;hop2deep@gmail.com&gt; |
| **Date** | 2026-07-17T23:35:09+08:00Z |
| **Changed** | 15 files, +360/-9 |

📝 Recent Commits

- [`8a7abeba6e0`](https://github.com/microsoft/vscode/commit/8a7abeba6e0) fix: restore 8 KiB Node buffer pool on linux (#326334)
- [`b86e21ea982`](https://github.com/microsoft/vscode/commit/b86e21ea982) Reland &quot;chore: update electron@42.6.0&quot; (#326277)
- [`2075dc76aa0`](https://github.com/microsoft/vscode/commit/2075dc76aa0) Bump version to 1.129.1 (#326222)
- [`6acd0b9a3b7`](https://github.com/microsoft/vscode/commit/6acd0b9a3b7) Revert &quot;chore: update electron@42.6.0 (#325428)&quot; (#326219)
- [`18284a2f5ff`](https://github.com/microsoft/vscode/commit/18284a2f5ff) Fix remote Agent Host dependency packaging (#326019) (#326075)
- [`6e3c53c9430`](https://github.com/microsoft/vscode/commit/6e3c53c9430) Merge pull request #326058 from microsoft/connor/defer-mcp-dynamic-registration-release-1.129
- [`cc2661465d8`](https://github.com/microsoft/vscode/commit/cc2661465d8) agentHost: add release MCP auth test imports
- [`d84b2adc0cf`](https://github.com/microsoft/vscode/commit/d84b2adc0cf) agentHost: defer interactive MCP client registration

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/125df46...8a7abeb)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
