### PR TITLE
update(apps/readest): update latest version to 0.11.20, update test version to 0.11.20

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.18",
-      "sha": "4af203755d807ae317c9ffe4922f5f1e7989a66b",
+      "version": "0.11.20",
+      "sha": "1df1505fc5033fc949463c9908f2d53bd0fbdfa6",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.18",
-      "sha": "4af203755d807ae317c9ffe4922f5f1e7989a66b",
+      "version": "0.11.20",
+      "sha": "1df1505fc5033fc949463c9908f2d53bd0fbdfa6",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.18"
+VERSION="v0.11.20"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.18"
+VERSION="v0.11.20"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.18` → `0.11.20` | [`4af2037`](https://github.com/readest/readest/commit/4af203755d807ae317c9ffe4922f5f1e7989a66b) → [`1df1505`](https://github.com/readest/readest/commit/1df1505fc5033fc949463c9908f2d53bd0fbdfa6) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.18` → `0.11.20` | [`4af2037`](https://github.com/readest/readest/commit/4af203755d807ae317c9ffe4922f5f1e7989a66b) → [`1df1505`](https://github.com/readest/readest/commit/1df1505fc5033fc949463c9908f2d53bd0fbdfa6) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.20 (#5220) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-07-20T04:10:21+08:00Z |
| **Changed** | 669 files, +38434/-6666 |

📝 Recent Commits

- [`1df1505f`](https://github.com/readest/readest/commit/1df1505f) release: version 0.11.20 (#5220)
- [`3605c9ef`](https://github.com/readest/readest/commit/3605c9ef) fix(ios): re-attach App Group to widget/share extensions in App Store builds (#5219)
- [`2aa044d2`](https://github.com/readest/readest/commit/2aa044d2) fix(reader): keep captured turns aligned with the finger (#5217)
- [`f3930b81`](https://github.com/readest/readest/commit/f3930b81) fix(reader): keep TTS media session and volume control with volume-key paging (#5218)
- [`633ac5ac`](https://github.com/readest/readest/commit/633ac5ac) fix(reader): make the custom theme editor readable on mobile (#5212)
- [`4512f398`](https://github.com/readest/readest/commit/4512f398) fix(reader): gate concurrent programmatic captured page turns (#5211)
- [`5191b327`](https://github.com/readest/readest/commit/5191b327) chore: update agent memories (#5209)
- [`7b12f190`](https://github.com/readest/readest/commit/7b12f190) fix(reader): draw the theme background on the curl back face (#5208)
- [`bf47da33`](https://github.com/readest/readest/commit/bf47da33) fix(applock): hide PIN entry while the biometric sheet is on screen (#5207)
- [`8ba9cf27`](https://github.com/readest/readest/commit/8ba9cf27) feat(reader): add right-edge swipe to adjust auto scroll speed (#5206)

[🔗 View full comparison](https://github.com/readest/readest/compare/4af2037...1df1505)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.11.20 (#5220) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-07-20T04:10:21+08:00Z |
| **Changed** | 669 files, +38434/-6666 |

📝 Recent Commits

- [`1df1505f`](https://github.com/readest/readest/commit/1df1505f) release: version 0.11.20 (#5220)
- [`3605c9ef`](https://github.com/readest/readest/commit/3605c9ef) fix(ios): re-attach App Group to widget/share extensions in App Store builds (#5219)
- [`2aa044d2`](https://github.com/readest/readest/commit/2aa044d2) fix(reader): keep captured turns aligned with the finger (#5217)
- [`f3930b81`](https://github.com/readest/readest/commit/f3930b81) fix(reader): keep TTS media session and volume control with volume-key paging (#5218)
- [`633ac5ac`](https://github.com/readest/readest/commit/633ac5ac) fix(reader): make the custom theme editor readable on mobile (#5212)
- [`4512f398`](https://github.com/readest/readest/commit/4512f398) fix(reader): gate concurrent programmatic captured page turns (#5211)
- [`5191b327`](https://github.com/readest/readest/commit/5191b327) chore: update agent memories (#5209)
- [`7b12f190`](https://github.com/readest/readest/commit/7b12f190) fix(reader): draw the theme background on the curl back face (#5208)
- [`bf47da33`](https://github.com/readest/readest/commit/bf47da33) fix(applock): hide PIN entry while the biometric sheet is on screen (#5207)
- [`8ba9cf27`](https://github.com/readest/readest/commit/8ba9cf27) feat(reader): add right-edge swipe to adjust auto scroll speed (#5206)

[🔗 View full comparison](https://github.com/readest/readest/compare/4af2037...1df1505)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
