### PR TITLE
update(apps/excalidraw): update dev version to 53732f0

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "5cf5476",
-      "sha": "5cf547650b700b35507e83773695098150b810d2",
+      "version": "53732f0",
+      "sha": "53732f08f430ded353121c64c230b448282be37a",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="5cf5476"
+VERSION="53732f0"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `5cf5476` → `53732f0` | [`5cf5476`](https://github.com/excalidraw/excalidraw/commit/5cf547650b700b35507e83773695098150b810d2) → [`53732f0`](https://github.com/excalidraw/excalidraw/commit/53732f08f430ded353121c64c230b448282be37a) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): prevent eyedropper preview from overflowing viewport  (#11722) |
| **Author** | samiran &lt;sam.de.721166@gmail.com&gt; |
| **Date** | 2026-07-22T06:07:15+08:00Z |
| **Changed** | 12 files, +314/-53 |

📝 Recent Commits

- [`53732f08`](https://github.com/excalidraw/excalidraw/commit/53732f08) fix(editor): prevent eyedropper preview from overflowing viewport  (#11722)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/5cf5476...53732f0)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
