### PR TITLE
update(apps/excalidraw): update dev version to a3b9089

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "53732f0",
-      "sha": "53732f08f430ded353121c64c230b448282be37a",
+      "version": "a3b9089",
+      "sha": "a3b90897b5d770a27d53773db670ddfda983ae85",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="53732f0"
+VERSION="a3b9089"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `53732f0` → `a3b9089` | [`53732f0`](https://github.com/excalidraw/excalidraw/commit/53732f08f430ded353121c64c230b448282be37a) → [`a3b9089`](https://github.com/excalidraw/excalidraw/commit/a3b90897b5d770a27d53773db670ddfda983ae85) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): Lost focus point on transition to inside-inside (#10964) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-07-22T19:03:45+08:00Z |
| **Changed** | 5 files, +127/-57 |

📝 Recent Commits

- [`a3b90897`](https://github.com/excalidraw/excalidraw/commit/a3b90897) fix(editor): Lost focus point on transition to inside-inside (#10964)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/53732f0...a3b9089)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
