### PR TITLE
update(base/vscode): update latest version to 1.130.0, update stable version to 1.130.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.129.1
+ARG VERSION=1.130.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.1 -> 1.129.1.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.130.0 -> 1.130.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.129.1
+ARG VERSION=1.130.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.129.1 -> 1.129.1.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.130.0 -> 1.130.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.129.1",
-      "sha": "8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8",
+      "version": "1.130.0",
+      "sha": "1b6a188127eeaf9194f945eb6eb89a657e93c54c",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.129.1",
-      "sha": "8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8",
+      "version": "1.130.0",
+      "sha": "1b6a188127eeaf9194f945eb6eb89a657e93c54c",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.129.1` → `1.130.0` | [`8a7abeb`](https://github.com/microsoft/vscode/commit/8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8) → [`1b6a188`](https://github.com/microsoft/vscode/commit/1b6a188127eeaf9194f945eb6eb89a657e93c54c) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.129.1` → `1.130.0` | [`8a7abeb`](https://github.com/microsoft/vscode/commit/8a7abeba6e03ea3af87bfbce9a1b7e48fed567b8) → [`1b6a188`](https://github.com/microsoft/vscode/commit/1b6a188127eeaf9194f945eb6eb89a657e93c54c) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Agents - fix isolation mode regression (#326973) (#326977) |
| **Author** | Ladislau Szomoru &lt;3372902+lszomoru@users.noreply.github.com&gt; |
| **Date** | 2026-07-22T22:55:04+08:00Z |
| **Changed** | 1102 files, +95457/-19445 |

📝 Recent Commits

- [`1b6a188127e`](https://github.com/microsoft/vscode/commit/1b6a188127e) Agents - fix isolation mode regression (#326973) (#326977)
- [`e5381e4f30c`](https://github.com/microsoft/vscode/commit/e5381e4f30c) [cherry-pick] NES: split open-tab vs related-file neighbor context (#326741)
- [`0e04915922a`](https://github.com/microsoft/vscode/commit/0e04915922a) [cherry-pick] Fix submenu rendering in modern UI (#326763)
- [`f9a0f54cef5`](https://github.com/microsoft/vscode/commit/f9a0f54cef5) Fix sandbox dependency installation on apt systems (#326748)
- [`0de19244e45`](https://github.com/microsoft/vscode/commit/0de19244e45) [cherry-pick] Add telemetry for applied enterprise policies (#326716)
- [`d4434528dd2`](https://github.com/microsoft/vscode/commit/d4434528dd2) [cherry-pick] Revert &quot;Forward CAPI assignment context to VS Code core telemetry&quot; (#326682)
- [`d3c8e165255`](https://github.com/microsoft/vscode/commit/d3c8e165255) Open Markdown editor in locked mode by default
- [`e586b8ac6e7`](https://github.com/microsoft/vscode/commit/e586b8ac6e7) Carry subagent task prompt on the subagent_started signal (#326545)
- [`3296e952c88`](https://github.com/microsoft/vscode/commit/3296e952c88) Reorganize Agent Host integration tests (#326531)
- [`5b3e1be7be9`](https://github.com/microsoft/vscode/commit/5b3e1be7be9) Update HIDDEN_RUNTIME_COMMANDS to include additional commands for improved functionality (#326168)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/8a7abeb...1b6a188)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Agents - fix isolation mode regression (#326973) (#326977) |
| **Author** | Ladislau Szomoru &lt;3372902+lszomoru@users.noreply.github.com&gt; |
| **Date** | 2026-07-22T22:55:04+08:00Z |
| **Changed** | 1102 files, +95457/-19445 |

📝 Recent Commits

- [`1b6a188127e`](https://github.com/microsoft/vscode/commit/1b6a188127e) Agents - fix isolation mode regression (#326973) (#326977)
- [`e5381e4f30c`](https://github.com/microsoft/vscode/commit/e5381e4f30c) [cherry-pick] NES: split open-tab vs related-file neighbor context (#326741)
- [`0e04915922a`](https://github.com/microsoft/vscode/commit/0e04915922a) [cherry-pick] Fix submenu rendering in modern UI (#326763)
- [`f9a0f54cef5`](https://github.com/microsoft/vscode/commit/f9a0f54cef5) Fix sandbox dependency installation on apt systems (#326748)
- [`0de19244e45`](https://github.com/microsoft/vscode/commit/0de19244e45) [cherry-pick] Add telemetry for applied enterprise policies (#326716)
- [`d4434528dd2`](https://github.com/microsoft/vscode/commit/d4434528dd2) [cherry-pick] Revert &quot;Forward CAPI assignment context to VS Code core telemetry&quot; (#326682)
- [`d3c8e165255`](https://github.com/microsoft/vscode/commit/d3c8e165255) Open Markdown editor in locked mode by default
- [`e586b8ac6e7`](https://github.com/microsoft/vscode/commit/e586b8ac6e7) Carry subagent task prompt on the subagent_started signal (#326545)
- [`3296e952c88`](https://github.com/microsoft/vscode/commit/3296e952c88) Reorganize Agent Host integration tests (#326531)
- [`5b3e1be7be9`](https://github.com/microsoft/vscode/commit/5b3e1be7be9) Update HIDDEN_RUNTIME_COMMANDS to include additional commands for improved functionality (#326168)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/8a7abeb...1b6a188)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
