### PR TITLE
update(apps/excalidraw): update dev version to e6ae6bf

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "a3b9089",
-      "sha": "a3b90897b5d770a27d53773db670ddfda983ae85",
+      "version": "e6ae6bf",
+      "sha": "e6ae6bf05755eb3845d9635953bd6477e948a8f6",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="a3b9089"
+VERSION="e6ae6bf"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `a3b9089` → `e6ae6bf` | [`a3b9089`](https://github.com/excalidraw/excalidraw/commit/a3b90897b5d770a27d53773db670ddfda983ae85) → [`e6ae6bf`](https://github.com/excalidraw/excalidraw/commit/e6ae6bf05755eb3845d9635953bd6477e948a8f6) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): Diamond hit test shortcut (#11631) |
| **Author** | Márk Tolmács &lt;mark@lazycat.hu&gt; |
| **Date** | 2026-07-23T04:39:16+08:00Z |
| **Changed** | 7 files, +99/-42 |

📝 Recent Commits

- [`e6ae6bf0`](https://github.com/excalidraw/excalidraw/commit/e6ae6bf0) fix(editor): Diamond hit test shortcut (#11631)
- [`91b78903`](https://github.com/excalidraw/excalidraw/commit/91b78903) fix(editor): Dangling deleted bound text (#11733)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/a3b9089...e6ae6bf)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
