### PR TITLE
update(apps/excalidraw): update dev version to 7c0b329

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "b2e81e3",
-      "sha": "b2e81e38a6fde8b3cb5dfdf2f2fb651323ad309d",
+      "version": "7c0b329",
+      "sha": "7c0b3295760d3492a980f2f6416a36c9ef592103",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="b2e81e3"
+VERSION="7c0b329"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `b2e81e3` → `7c0b329` | [`b2e81e3`](https://github.com/excalidraw/excalidraw/commit/b2e81e38a6fde8b3cb5dfdf2f2fb651323ad309d) → [`7c0b329`](https://github.com/excalidraw/excalidraw/commit/7c0b3295760d3492a980f2f6416a36c9ef592103) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): increase autoresize handle threshold until it hides (#11773) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-07-28T05:04:03+08:00Z |
| **Changed** | 1 files, +3/-2 |

📝 Recent Commits

- [`7c0b3295`](https://github.com/excalidraw/excalidraw/commit/7c0b3295) fix(editor): increase autoresize handle threshold until it hides (#11773)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/b2e81e3...7c0b329)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
