### PR TITLE
update(apps/dashboard-icons): update latest version to 03e8f8e

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "46b860c",
-      "sha": "46b860c70e866212311aef2f98da3775c17f5068",
+      "version": "03e8f8e",
+      "sha": "03e8f8e22da16ccddf5e14afa90711391357231e",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="46b860c"
+VERSION="03e8f8e"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `46b860c` → `03e8f8e` | [`46b860c`](https://github.com/homarr-labs/dashboard-icons/commit/46b860c70e866212311aef2f98da3775c17f5068) → [`03e8f8e`](https://github.com/homarr-labs/dashboard-icons/commit/03e8f8e22da16ccddf5e14afa90711391357231e) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | ci(github-actions): convert SVG assets to PNG and WEBP |
| **Author** | Dashboard Icons Bot &lt;homarr-labs@proton.me&gt; |
| **Date** | 2026-07-28T17:54:46+08:00Z |
| **Changed** | 238 files, +2028/-22 |

📝 Recent Commits

- [`03e8f8e2`](https://github.com/homarr-labs/dashboard-icons/commit/03e8f8e2) ci(github-actions): convert SVG assets to PNG and WEBP
- [`7ab88855`](https://github.com/homarr-labs/dashboard-icons/commit/7ab88855) chore: add icon &quot;supernote-private-cloud&quot; (submission ef922nuph79glvj, approved by manuel-rw)
- [`ca15e7b2`](https://github.com/homarr-labs/dashboard-icons/commit/ca15e7b2) chore: add icon &quot;fluxer&quot; (submission nwrpxccj0bsv8dn, approved by ajnart)
- [`83baa5bf`](https://github.com/homarr-labs/dashboard-icons/commit/83baa5bf) chore: add icon &quot;homebrew&quot; (submission 2fket8rnet7uwpr, approved by ajnart)
- [`cfb90e86`](https://github.com/homarr-labs/dashboard-icons/commit/cfb90e86) chore: add icon &quot;scrob&quot; (submission kf2k6lipsrrox6g, approved by ajnart)
- [`a8d107ed`](https://github.com/homarr-labs/dashboard-icons/commit/a8d107ed) chore: add icon &quot;breachlab&quot; (submission vy4p3iv9rgbtdzx, approved by ajnart)
- [`330a7743`](https://github.com/homarr-labs/dashboard-icons/commit/330a7743) chore: add icon &quot;asus-gt-be98&quot; (submission yrjwpprhacvxn1u, approved by ajnart)
- [`21dc6867`](https://github.com/homarr-labs/dashboard-icons/commit/21dc6867) chore: add icon &quot;llm-router&quot; (submission 0ap2138gnhc4eaz, approved by ajnart)
- [`260deb26`](https://github.com/homarr-labs/dashboard-icons/commit/260deb26) chore: add icon &quot;ngrok&quot; (submission b11ywoahy95659s, approved by ajnart)
- [`ed17f290`](https://github.com/homarr-labs/dashboard-icons/commit/ed17f290) chore: add icon &quot;neutarr&quot; (submission vo1217hnxvjj9ai, approved by ajnart)

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/46b860c...03e8f8e)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
