### PR TITLE
update(apps/excalidraw): update dev version to 1acf66e

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "7c0b329",
-      "sha": "7c0b3295760d3492a980f2f6416a36c9ef592103",
+      "version": "1acf66e",
+      "sha": "1acf66edabc2ac5bbd4aed0714aed7dca7cc2aab",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="7c0b329"
+VERSION="1acf66e"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `7c0b329` → `1acf66e` | [`7c0b329`](https://github.com/excalidraw/excalidraw/commit/7c0b3295760d3492a980f2f6416a36c9ef592103) → [`1acf66e`](https://github.com/excalidraw/excalidraw/commit/1acf66edabc2ac5bbd4aed0714aed7dca7cc2aab) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(editor): bind text to hovered arrow endpoint (#11777) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-07-29T00:12:33+08:00Z |
| **Changed** | 22 files, +2127/-175 |

📝 Recent Commits

- [`1acf66ed`](https://github.com/excalidraw/excalidraw/commit/1acf66ed) feat(editor): bind text to hovered arrow endpoint (#11777)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/7c0b329...1acf66e)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
