### PR TITLE
update(base/vscode): update latest version to 1.131.0, update stable version to 1.131.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.130.0
+ARG VERSION=1.131.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.130.0 -> 1.130.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.131.0 -> 1.131.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.130.0
+ARG VERSION=1.131.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.130.0 -> 1.130.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.131.0 -> 1.131.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.130.0",
-      "sha": "1b6a188127eeaf9194f945eb6eb89a657e93c54c",
+      "version": "1.131.0",
+      "sha": "3a03d6f72d628a7741c29f456b4ddbb5ae68502c",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.130.0",
-      "sha": "1b6a188127eeaf9194f945eb6eb89a657e93c54c",
+      "version": "1.131.0",
+      "sha": "3a03d6f72d628a7741c29f456b4ddbb5ae68502c",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.130.0` → `1.131.0` | [`1b6a188`](https://github.com/microsoft/vscode/commit/1b6a188127eeaf9194f945eb6eb89a657e93c54c) → [`3a03d6f`](https://github.com/microsoft/vscode/commit/3a03d6f72d628a7741c29f456b4ddbb5ae68502c) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.130.0` → `1.131.0` | [`1b6a188`](https://github.com/microsoft/vscode/commit/1b6a188127eeaf9194f945eb6eb89a657e93c54c) → [`3a03d6f`](https://github.com/microsoft/vscode/commit/3a03d6f72d628a7741c29f456b4ddbb5ae68502c) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Correct the error message to show when Host restricts bwrap execution (#327766) |
| **Author** | Dileep Yavanmandha &lt;52841896+dileepyavan@users.noreply.github.com&gt; |
| **Date** | 2026-07-28T14:40:51+08:00Z |
| **Changed** | 1073 files, +64249/-27520 |

📝 Recent Commits

- [`3a03d6f72d6`](https://github.com/microsoft/vscode/commit/3a03d6f72d6) Correct the error message to show when Host restricts bwrap execution (#327766)
- [`89f97b7558e`](https://github.com/microsoft/vscode/commit/89f97b7558e) [cherry-pick] Don&#39;t replay a signed thinking block onto rounds that never had one (#327748)
- [`2a210f1dffa`](https://github.com/microsoft/vscode/commit/2a210f1dffa) Enable terminal sandboxing inside containers (#327680)
- [`29a4ba5dcc1`](https://github.com/microsoft/vscode/commit/29a4ba5dcc1) Auto-open model picker in session onboarding (#327718)
- [`615e3432dc6`](https://github.com/microsoft/vscode/commit/615e3432dc6) [cherry-pick] Revert &quot;rotating empty state messaging&quot; (#327704)
- [`c817088960f`](https://github.com/microsoft/vscode/commit/c817088960f) [cherry-pick] pet: fix language around setting (#327700)
- [`8cd3649ab0e`](https://github.com/microsoft/vscode/commit/8cd3649ab0e) [cherry-pick] Change default for AH BYOK setting to false (#327674)
- [`f4cdffbaa38`](https://github.com/microsoft/vscode/commit/f4cdffbaa38) [cherry-pick] Keep workspace-less quick chats out of bogus workspace groups (#327654)
- [`03e44cdbd5d`](https://github.com/microsoft/vscode/commit/03e44cdbd5d) [cherry-pick] fix subagent gap (#327657)
- [`89e7b2e4756`](https://github.com/microsoft/vscode/commit/89e7b2e4756) Bump @vscode/markdown-editor to 0.0.2-24

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/1b6a188...3a03d6f)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Correct the error message to show when Host restricts bwrap execution (#327766) |
| **Author** | Dileep Yavanmandha &lt;52841896+dileepyavan@users.noreply.github.com&gt; |
| **Date** | 2026-07-28T14:40:51+08:00Z |
| **Changed** | 1073 files, +64249/-27520 |

📝 Recent Commits

- [`3a03d6f72d6`](https://github.com/microsoft/vscode/commit/3a03d6f72d6) Correct the error message to show when Host restricts bwrap execution (#327766)
- [`89f97b7558e`](https://github.com/microsoft/vscode/commit/89f97b7558e) [cherry-pick] Don&#39;t replay a signed thinking block onto rounds that never had one (#327748)
- [`2a210f1dffa`](https://github.com/microsoft/vscode/commit/2a210f1dffa) Enable terminal sandboxing inside containers (#327680)
- [`29a4ba5dcc1`](https://github.com/microsoft/vscode/commit/29a4ba5dcc1) Auto-open model picker in session onboarding (#327718)
- [`615e3432dc6`](https://github.com/microsoft/vscode/commit/615e3432dc6) [cherry-pick] Revert &quot;rotating empty state messaging&quot; (#327704)
- [`c817088960f`](https://github.com/microsoft/vscode/commit/c817088960f) [cherry-pick] pet: fix language around setting (#327700)
- [`8cd3649ab0e`](https://github.com/microsoft/vscode/commit/8cd3649ab0e) [cherry-pick] Change default for AH BYOK setting to false (#327674)
- [`f4cdffbaa38`](https://github.com/microsoft/vscode/commit/f4cdffbaa38) [cherry-pick] Keep workspace-less quick chats out of bogus workspace groups (#327654)
- [`03e44cdbd5d`](https://github.com/microsoft/vscode/commit/03e44cdbd5d) [cherry-pick] fix subagent gap (#327657)
- [`89e7b2e4756`](https://github.com/microsoft/vscode/commit/89e7b2e4756) Bump @vscode/markdown-editor to 0.0.2-24

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/1b6a188...3a03d6f)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
