### PR TITLE
update(apps/excalidraw): update dev version to 69d4c34

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "1acf66e",
-      "sha": "1acf66edabc2ac5bbd4aed0714aed7dca7cc2aab",
+      "version": "69d4c34",
+      "sha": "69d4c346cc82ee5f64b6fa6bb91ad94422fedfb3",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="1acf66e"
+VERSION="69d4c34"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `1acf66e` → `69d4c34` | [`1acf66e`](https://github.com/excalidraw/excalidraw/commit/1acf66edabc2ac5bbd4aed0714aed7dca7cc2aab) → [`69d4c34`](https://github.com/excalidraw/excalidraw/commit/69d4c346cc82ee5f64b6fa6bb91ad94422fedfb3) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): prevent esc from exiting fullscreen on macos when modal open (#11789) |
| **Author** | Adam &lt;74390687+abobich675@users.noreply.github.com&gt; |
| **Date** | 2026-07-30T15:47:42+08:00Z |
| **Changed** | 2 files, +2/-0 |

📝 Recent Commits

- [`69d4c346`](https://github.com/excalidraw/excalidraw/commit/69d4c346) fix(editor): prevent esc from exiting fullscreen on macos when modal open (#11789)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/1acf66e...69d4c34)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
