### PR TITLE
update(apps/excalidraw): update dev version to 786ab26

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "69d4c34",
-      "sha": "69d4c346cc82ee5f64b6fa6bb91ad94422fedfb3",
+      "version": "786ab26",
+      "sha": "786ab266ff3a9cfffaed16804cf9132b44bc08ae",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="69d4c34"
+VERSION="786ab26"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `69d4c34` → `786ab26` | [`69d4c34`](https://github.com/excalidraw/excalidraw/commit/69d4c346cc82ee5f64b6fa6bb91ad94422fedfb3) → [`786ab26`](https://github.com/excalidraw/excalidraw/commit/786ab266ff3a9cfffaed16804cf9132b44bc08ae) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(editor): Error message for invalid hex color input (#11782) |
| **Author** | cyforkk &lt;165913369+cyforkk@users.noreply.github.com&gt; |
| **Date** | 2026-07-30T19:30:20+08:00Z |
| **Changed** | 5 files, +492/-175 |

📝 Recent Commits

- [`786ab266`](https://github.com/excalidraw/excalidraw/commit/786ab266) feat(editor): Error message for invalid hex color input (#11782)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/69d4c34...786ab26)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
