### PR TITLE
update(apps/weserv): update latest version to 63be426, update alpine version to 63be426

### DIFF
--- a/apps/weserv/Dockerfile
+++ b/apps/weserv/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=82c0144
+ARG VERSION=63be426
 ARG NGINX_VERSION=1.29.4
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 # Download NGINX source, because of rockylinux(arm64) can't extract it during build

--- a/apps/weserv/Dockerfile.alpine
+++ b/apps/weserv/Dockerfile.alpine
@@ -1,7 +1,7 @@
 FROM alpine/git AS source
 WORKDIR /app
 ARG BRANCH=5.x
-ARG VERSION=82c0144
+ARG VERSION=63be426
 RUN git clone -b ${BRANCH} --recurse-submodules https://github.com/weserv/images . && git checkout ${VERSION}
 
 # Based on:

--- a/apps/weserv/meta.json
+++ b/apps/weserv/meta.json
@@ -5,8 +5,8 @@
   "description": "weserv 是一个用于快速生成图像的 API",
   "variants": {
     "latest": {
-      "version": "82c0144",
-      "sha": "82c0144059bb9eda91177bd922d5625ddf74dfab",
+      "version": "63be426",
+      "sha": "63be4263c933a0a0cf14c11eb96fb65cf0e299e4",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",
@@ -21,8 +21,8 @@
       }
     },
     "alpine": {
-      "version": "82c0144",
-      "sha": "82c0144059bb9eda91177bd922d5625ddf74dfab",
+      "version": "63be426",
+      "sha": "63be4263c933a0a0cf14c11eb96fb65cf0e299e4",
       "checkver": {
         "type": "sha",
         "repo": "weserv/images",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `weserv` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`weserv/images`](https://github.com/weserv/images) | `82c0144` → `63be426` | [`82c0144`](https://github.com/weserv/images/commit/82c0144059bb9eda91177bd922d5625ddf74dfab) → [`63be426`](https://github.com/weserv/images/commit/63be4263c933a0a0cf14c11eb96fb65cf0e299e4) |
| `alpine` | [`weserv/images`](https://github.com/weserv/images) | `82c0144` → `63be426` | [`82c0144`](https://github.com/weserv/images/commit/82c0144059bb9eda91177bd922d5625ddf74dfab) → [`63be426`](https://github.com/weserv/images/commit/63be4263c933a0a0cf14c11eb96fb65cf0e299e4) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.18.4 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-07-31T21:35:05+08:00Z |
| **Changed** | 9 files, +51/-29 |

📝 Recent Commits

- [`63be426`](https://github.com/weserv/images/commit/63be426) Bump GitHub Actions libvips to 8.18.4
- [`4d7520b`](https://github.com/weserv/images/commit/4d7520b) CI: Upgrade `actions/cache` to v6
- [`e1b9aac`](https://github.com/weserv/images/commit/e1b9aac) Update nginx to 1.31.3
- [`632d575`](https://github.com/weserv/images/commit/632d575) Add web-safe ImageMagick policy.xml to Docker image
- [`5ac5760`](https://github.com/weserv/images/commit/5ac5760) Use RPM packages from weserv/rpms
- [`034e880`](https://github.com/weserv/images/commit/034e880) Simplify response body handling
- [`9507c83`](https://github.com/weserv/images/commit/9507c83) Simplify image limit error messages

[🔗 View full comparison](https://github.com/weserv/images/compare/82c0144...63be426)

</p></details>

<details><summary>alpine</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`weserv/images`](https://github.com/weserv/images) |
| **Latest Commit** | Bump GitHub Actions libvips to 8.18.4 |
| **Author** | Kleis Auke Wolthuizen &lt;github@kleisauke.nl&gt; |
| **Date** | 2026-07-31T21:35:05+08:00Z |
| **Changed** | 9 files, +51/-29 |

📝 Recent Commits

- [`63be426`](https://github.com/weserv/images/commit/63be426) Bump GitHub Actions libvips to 8.18.4
- [`4d7520b`](https://github.com/weserv/images/commit/4d7520b) CI: Upgrade `actions/cache` to v6
- [`e1b9aac`](https://github.com/weserv/images/commit/e1b9aac) Update nginx to 1.31.3
- [`632d575`](https://github.com/weserv/images/commit/632d575) Add web-safe ImageMagick policy.xml to Docker image
- [`5ac5760`](https://github.com/weserv/images/commit/5ac5760) Use RPM packages from weserv/rpms
- [`034e880`](https://github.com/weserv/images/commit/034e880) Simplify response body handling
- [`9507c83`](https://github.com/weserv/images/commit/9507c83) Simplify image limit error messages

[🔗 View full comparison](https://github.com/weserv/images/compare/82c0144...63be426)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
