### PR TITLE
update(apps/dashboard-icons): update latest version to 097dc23

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "03e8f8e",
-      "sha": "03e8f8e22da16ccddf5e14afa90711391357231e",
+      "version": "097dc23",
+      "sha": "097dc231142e06865e19f4e9cb0578c35bbd7ae3",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="03e8f8e"
+VERSION="097dc23"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `03e8f8e` → `097dc23` | [`03e8f8e`](https://github.com/homarr-labs/dashboard-icons/commit/03e8f8e22da16ccddf5e14afa90711391357231e) → [`097dc23`](https://github.com/homarr-labs/dashboard-icons/commit/097dc231142e06865e19f4e9cb0578c35bbd7ae3) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | Merge pull request #2885 from gfrancodev/feat/mcp-http-server |
| **Author** | Thomas &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-08-02T04:22:11+08:00Z |
| **Changed** | 75 files, +5780/-1809 |

📝 Recent Commits

- [`097dc231`](https://github.com/homarr-labs/dashboard-icons/commit/097dc231) Merge pull request #2885 from gfrancodev/feat/mcp-http-server
- [`6049b758`](https://github.com/homarr-labs/dashboard-icons/commit/6049b758) fix(web): address remaining CodeRabbit MCP review findings
- [`dca8c70e`](https://github.com/homarr-labs/dashboard-icons/commit/dca8c70e) fix(web): honor PostHog ingestion host
- [`7dd3caf0`](https://github.com/homarr-labs/dashboard-icons/commit/7dd3caf0) fix(web): address MCP review findings
- [`5f2cb5ec`](https://github.com/homarr-labs/dashboard-icons/commit/5f2cb5ec) feat(web): add PostHog MCP analytics
- [`f3c202cb`](https://github.com/homarr-labs/dashboard-icons/commit/f3c202cb) feat(web): add MCP setup UI, server branding, and e2e coverage
- [`14b17a76`](https://github.com/homarr-labs/dashboard-icons/commit/14b17a76) chore(web): bump dependencies and document MCP usage
- [`d6db5b7b`](https://github.com/homarr-labs/dashboard-icons/commit/d6db5b7b) fix(web): harden build, lint, and server/client boundaries
- [`a558e7e3`](https://github.com/homarr-labs/dashboard-icons/commit/a558e7e3) refactor(web): migrate middleware to proxy for Next.js 16
- [`54614686`](https://github.com/homarr-labs/dashboard-icons/commit/54614686) test(web): add MCP and icon library test coverage

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/03e8f8e...097dc23)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
