### PR TITLE
update(apps/dashboard-icons): update latest version to 94b7ca9

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "03e8f8e",
-      "sha": "03e8f8e22da16ccddf5e14afa90711391357231e",
+      "version": "94b7ca9",
+      "sha": "94b7ca97cb1caa42e7ba1daf23259d7ebe4f8a34",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="03e8f8e"
+VERSION="94b7ca9"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `03e8f8e` → `94b7ca9` | [`03e8f8e`](https://github.com/homarr-labs/dashboard-icons/commit/03e8f8e22da16ccddf5e14afa90711391357231e) → [`94b7ca9`](https://github.com/homarr-labs/dashboard-icons/commit/94b7ca97cb1caa42e7ba1daf23259d7ebe4f8a34) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | fix(web): tolerate unavailable GitHub authors |
| **Author** | Thomas Camlong &lt;thomas@ajnart.fr&gt; |
| **Date** | 2026-08-02T16:26:50+08:00Z |
| **Changed** | 77 files, +5805/-1814 |

📝 Recent Commits

- [`94b7ca97`](https://github.com/homarr-labs/dashboard-icons/commit/94b7ca97) fix(web): tolerate unavailable GitHub authors
- [`9c50cb6d`](https://github.com/homarr-labs/dashboard-icons/commit/9c50cb6d) Merge pull request #2886 from gfrancodev/fix/ci-docker-build
- [`51eff538`](https://github.com/homarr-labs/dashboard-icons/commit/51eff538) fix(web): restore Docker build after MCP merge
- [`c1dd0c3a`](https://github.com/homarr-labs/dashboard-icons/commit/c1dd0c3a) Revert &quot;Migrate workflows to Blacksmith&quot;
- [`097dc231`](https://github.com/homarr-labs/dashboard-icons/commit/097dc231) Merge pull request #2885 from gfrancodev/feat/mcp-http-server
- [`6049b758`](https://github.com/homarr-labs/dashboard-icons/commit/6049b758) fix(web): address remaining CodeRabbit MCP review findings
- [`dca8c70e`](https://github.com/homarr-labs/dashboard-icons/commit/dca8c70e) fix(web): honor PostHog ingestion host
- [`7dd3caf0`](https://github.com/homarr-labs/dashboard-icons/commit/7dd3caf0) fix(web): address MCP review findings
- [`5f2cb5ec`](https://github.com/homarr-labs/dashboard-icons/commit/5f2cb5ec) feat(web): add PostHog MCP analytics
- [`f3c202cb`](https://github.com/homarr-labs/dashboard-icons/commit/f3c202cb) feat(web): add MCP setup UI, server branding, and e2e coverage

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/03e8f8e...94b7ca9)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
