### PR TITLE
update(apps/excalidraw): update dev version to 39103bd

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "786ab26",
-      "sha": "786ab266ff3a9cfffaed16804cf9132b44bc08ae",
+      "version": "39103bd",
+      "sha": "39103bd33a3365f4134958fe5e932678fcd12fb8",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="786ab26"
+VERSION="39103bd"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `786ab26` → `39103bd` | [`786ab26`](https://github.com/excalidraw/excalidraw/commit/786ab266ff3a9cfffaed16804cf9132b44bc08ae) → [`39103bd`](https://github.com/excalidraw/excalidraw/commit/39103bd33a3365f4134958fe5e932678fcd12fb8) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | chore(editor): Update translations from Crowdin (#11813) |
| **Author** | Excalidraw Bot &lt;77840495+excalibot@users.noreply.github.com&gt; |
| **Date** | 2026-08-04T03:48:06+08:00Z |
| **Changed** | 57 files, +2023/-1407 |

📝 Recent Commits

- [`39103bd3`](https://github.com/excalidraw/excalidraw/commit/39103bd3) chore(editor): Update translations from Crowdin (#11813)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/786ab26...39103bd)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
