### PR TITLE
update(apps/excalidraw): update dev version to ab0255f

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "39103bd",
-      "sha": "39103bd33a3365f4134958fe5e932678fcd12fb8",
+      "version": "ab0255f",
+      "sha": "ab0255f21eb40b5408f3e9ed9725474108eda9e6",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="39103bd"
+VERSION="ab0255f"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `39103bd` → `ab0255f` | [`39103bd`](https://github.com/excalidraw/excalidraw/commit/39103bd33a3365f4134958fe5e932678fcd12fb8) → [`ab0255f`](https://github.com/excalidraw/excalidraw/commit/ab0255f21eb40b5408f3e9ed9725474108eda9e6) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): prevent crash when editing arrow with bound text (#11814) |
| **Author** | nihaarsirikonda &lt;nihaarsirikonda1@gmail.com&gt; |
| **Date** | 2026-08-04T22:31:37+08:00Z |
| **Changed** | 34 files, +5581/-142 |

📝 Recent Commits

- [`ab0255f2`](https://github.com/excalidraw/excalidraw/commit/ab0255f2) fix(editor): prevent crash when editing arrow with bound text (#11814)
- [`792ea3a0`](https://github.com/excalidraw/excalidraw/commit/792ea3a0) feat(editor): bucket fill (#11799)
- [`f1aa8f86`](https://github.com/excalidraw/excalidraw/commit/f1aa8f86) feat(editor): disable arrowhead toggle via dblclick (#11822)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/39103bd...ab0255f)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
