### PR TITLE
update(apps/excalidraw): update dev version to 5e375b4

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "85270fc",
-      "sha": "85270fcc8db26f98d119e2d2752b0c0139e86e16",
+      "version": "5e375b4",
+      "sha": "5e375b4331febad8dd7d1adf4e3d78df0fbeeb17",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="85270fc"
+VERSION="5e375b4"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `85270fc` → `5e375b4` | [`85270fc`](https://github.com/excalidraw/excalidraw/commit/85270fcc8db26f98d119e2d2752b0c0139e86e16) → [`5e375b4`](https://github.com/excalidraw/excalidraw/commit/5e375b4331febad8dd7d1adf4e3d78df0fbeeb17) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): do not flicker bbox when drag-creating line midpoint (#11834) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-08-05T16:52:10+08:00Z |
| **Changed** | 2 files, +50/-2 |

📝 Recent Commits

- [`5e375b43`](https://github.com/excalidraw/excalidraw/commit/5e375b43) fix(editor): do not flicker bbox when drag-creating line midpoint (#11834)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/85270fc...5e375b4)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
