### PR TITLE
update(base/vscode): update latest version to 1.132.0, update stable version to 1.132.0

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.131.0
+ARG VERSION=1.132.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.131.0 -> 1.131.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.132.0 -> 1.132.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.131.0
+ARG VERSION=1.132.0
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.131.0 -> 1.131.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.132.0 -> 1.132.0.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.131.0",
-      "sha": "3a03d6f72d628a7741c29f456b4ddbb5ae68502c",
+      "version": "1.132.0",
+      "sha": "df53daabb18cd157bdb08c7f01c34df936cf12f4",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.131.0",
-      "sha": "3a03d6f72d628a7741c29f456b4ddbb5ae68502c",
+      "version": "1.132.0",
+      "sha": "df53daabb18cd157bdb08c7f01c34df936cf12f4",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.131.0` → `1.132.0` | [`3a03d6f`](https://github.com/microsoft/vscode/commit/3a03d6f72d628a7741c29f456b4ddbb5ae68502c) → [`df53daa`](https://github.com/microsoft/vscode/commit/df53daabb18cd157bdb08c7f01c34df936cf12f4) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.131.0` → `1.132.0` | [`3a03d6f`](https://github.com/microsoft/vscode/commit/3a03d6f72d628a7741c29f456b4ddbb5ae68502c) → [`df53daa`](https://github.com/microsoft/vscode/commit/df53daabb18cd157bdb08c7f01c34df936cf12f4) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Pre-seed Integrated Browser smoke settings to avoid the relaunch prompt (#328972) |
| **Author** | Benjamin Christopher Simmonds &lt;44439583+benibenj@users.noreply.github.com&gt; |
| **Date** | 2026-08-04T23:30:20+08:00Z |
| **Changed** | 1518 files, +130306/-22081 |

📝 Recent Commits

- [`df53daabb18`](https://github.com/microsoft/vscode/commit/df53daabb18) Pre-seed Integrated Browser smoke settings to avoid the relaunch prompt (#328972)
- [`cc5405f4cf0`](https://github.com/microsoft/vscode/commit/cc5405f4cf0) Force custom menus in Integrated Browser smoke tests (#328969)
- [`868a0535514`](https://github.com/microsoft/vscode/commit/868a0535514) [cherry-pick] Label sessions archived section per archive wording setting
- [`537399d1e7f`](https://github.com/microsoft/vscode/commit/537399d1e7f) [cherry-pick] build(deps): bump @vscode/markdown-editor from 0.0.2-40 to 0.0.2-41 in /extensions/markdown-language-features (#328827)
- [`bdc4ace1c99`](https://github.com/microsoft/vscode/commit/bdc4ace1c99) [cherry-pick] Fix default thinking effort (#328873)
- [`e5b4addd5c7`](https://github.com/microsoft/vscode/commit/e5b4addd5c7) Revert https://github.com/microsoft/vscode/pull/327408 (#328871)
- [`82b074f340a`](https://github.com/microsoft/vscode/commit/82b074f340a) Merge pull request #328806 from microsoft/cherry-pick/328785
- [`8ac64d11677`](https://github.com/microsoft/vscode/commit/8ac64d11677) [cherry-pick] Implement end-to-end BYOK image support and regression tests
- [`265ab0558e6`](https://github.com/microsoft/vscode/commit/265ab0558e6) [cherry-pick] Sessions: Revert session archive animation (#328718)
- [`ed8fd7ce4e4`](https://github.com/microsoft/vscode/commit/ed8fd7ce4e4) Merge pull request #328740 from connor4312/connor4312/328641-release-1.132

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/3a03d6f...df53daa)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Pre-seed Integrated Browser smoke settings to avoid the relaunch prompt (#328972) |
| **Author** | Benjamin Christopher Simmonds &lt;44439583+benibenj@users.noreply.github.com&gt; |
| **Date** | 2026-08-04T23:30:20+08:00Z |
| **Changed** | 1518 files, +130306/-22081 |

📝 Recent Commits

- [`df53daabb18`](https://github.com/microsoft/vscode/commit/df53daabb18) Pre-seed Integrated Browser smoke settings to avoid the relaunch prompt (#328972)
- [`cc5405f4cf0`](https://github.com/microsoft/vscode/commit/cc5405f4cf0) Force custom menus in Integrated Browser smoke tests (#328969)
- [`868a0535514`](https://github.com/microsoft/vscode/commit/868a0535514) [cherry-pick] Label sessions archived section per archive wording setting
- [`537399d1e7f`](https://github.com/microsoft/vscode/commit/537399d1e7f) [cherry-pick] build(deps): bump @vscode/markdown-editor from 0.0.2-40 to 0.0.2-41 in /extensions/markdown-language-features (#328827)
- [`bdc4ace1c99`](https://github.com/microsoft/vscode/commit/bdc4ace1c99) [cherry-pick] Fix default thinking effort (#328873)
- [`e5b4addd5c7`](https://github.com/microsoft/vscode/commit/e5b4addd5c7) Revert https://github.com/microsoft/vscode/pull/327408 (#328871)
- [`82b074f340a`](https://github.com/microsoft/vscode/commit/82b074f340a) Merge pull request #328806 from microsoft/cherry-pick/328785
- [`8ac64d11677`](https://github.com/microsoft/vscode/commit/8ac64d11677) [cherry-pick] Implement end-to-end BYOK image support and regression tests
- [`265ab0558e6`](https://github.com/microsoft/vscode/commit/265ab0558e6) [cherry-pick] Sessions: Revert session archive animation (#328718)
- [`ed8fd7ce4e4`](https://github.com/microsoft/vscode/commit/ed8fd7ce4e4) Merge pull request #328740 from connor4312/connor4312/328641-release-1.132

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/3a03d6f...df53daa)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
