### PR TITLE
update(apps/excalidraw): update dev version to e33a1c0

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "5e375b4",
-      "sha": "5e375b4331febad8dd7d1adf4e3d78df0fbeeb17",
+      "version": "e33a1c0",
+      "sha": "e33a1c0e85a9fae8636deb9b9eb7079825de8337",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="5e375b4"
+VERSION="e33a1c0"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `5e375b4` → `e33a1c0` | [`5e375b4`](https://github.com/excalidraw/excalidraw/commit/5e375b4331febad8dd7d1adf4e3d78df0fbeeb17) → [`e33a1c0`](https://github.com/excalidraw/excalidraw/commit/e33a1c0e85a9fae8636deb9b9eb7079825de8337) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(packages/excalidraw): do not dedupe collaborators (#11835) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-08-05T20:20:18+08:00Z |
| **Changed** | 4 files, +111/-34 |

📝 Recent Commits

- [`e33a1c0e`](https://github.com/excalidraw/excalidraw/commit/e33a1c0e) feat(packages/excalidraw): do not dedupe collaborators (#11835)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/5e375b4...e33a1c0)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
