### PR TITLE
update(apps/excalidraw): update dev version to 7478958

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "e33a1c0",
-      "sha": "e33a1c0e85a9fae8636deb9b9eb7079825de8337",
+      "version": "7478958",
+      "sha": "74789584bed7de19e91e35a3c0e708aeadcddf8b",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="e33a1c0"
+VERSION="7478958"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `e33a1c0` → `7478958` | [`e33a1c0`](https://github.com/excalidraw/excalidraw/commit/e33a1c0e85a9fae8636deb9b9eb7079825de8337) → [`7478958`](https://github.com/excalidraw/excalidraw/commit/74789584bed7de19e91e35a3c0e708aeadcddf8b) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(packages/excalidraw): support ViewportStatusFrame label onClick (#11838) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-08-06T00:28:52+08:00Z |
| **Changed** | 5 files, +74/-15 |

📝 Recent Commits

- [`74789584`](https://github.com/excalidraw/excalidraw/commit/74789584) feat(packages/excalidraw): support ViewportStatusFrame label onClick (#11838)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/e33a1c0...7478958)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
