### PR TITLE
update(apps/excalidraw): update dev version to e4ab626

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "7478958",
-      "sha": "74789584bed7de19e91e35a3c0e708aeadcddf8b",
+      "version": "e4ab626",
+      "sha": "e4ab626739f5f163c5eca56190f615643218b61c",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="7478958"
+VERSION="e4ab626"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `7478958` → `e4ab626` | [`7478958`](https://github.com/excalidraw/excalidraw/commit/74789584bed7de19e91e35a3c0e708aeadcddf8b) → [`e4ab626`](https://github.com/excalidraw/excalidraw/commit/e4ab626739f5f163c5eca56190f615643218b61c) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(packages/excalidraw): add `props.className` (#11839) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-08-06T02:10:18+08:00Z |
| **Changed** | 7 files, +87/-25 |

📝 Recent Commits

- [`e4ab6267`](https://github.com/excalidraw/excalidraw/commit/e4ab6267) feat(packages/excalidraw): add `props.className` (#11839)
- [`1e22618a`](https://github.com/excalidraw/excalidraw/commit/1e22618a) fix(packages/excalidraw): viewportStatusFrame label offset on mobile (#11840)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/7478958...e4ab626)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
