### PR TITLE
update(apps/excalidraw): update dev version to 219571a

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "e4ab626",
-      "sha": "e4ab626739f5f163c5eca56190f615643218b61c",
+      "version": "219571a",
+      "sha": "219571a7187651c79648de08c9a98a3b2f7f607a",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="e4ab626"
+VERSION="219571a"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `e4ab626` → `219571a` | [`e4ab626`](https://github.com/excalidraw/excalidraw/commit/e4ab626739f5f163c5eca56190f615643218b61c) → [`219571a`](https://github.com/excalidraw/excalidraw/commit/219571a7187651c79648de08c9a98a3b2f7f607a) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | fix(editor): viewportportStatusFrame UI fixes (#11841) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-08-07T04:01:48+08:00Z |
| **Changed** | 8 files, +237/-99 |

📝 Recent Commits

- [`219571a7`](https://github.com/excalidraw/excalidraw/commit/219571a7) fix(editor): viewportportStatusFrame UI fixes (#11841)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/e4ab626...219571a)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
