### PR TITLE
update(apps/readest): update latest version to 0.12.1, update test version to 0.12.1

### DIFF
--- a/apps/readest/meta.json
+++ b/apps/readest/meta.json
@@ -7,16 +7,16 @@
   "license": "AGPL-3.0",
   "variants": {
     "latest": {
-      "version": "0.11.20",
-      "sha": "1df1505fc5033fc949463c9908f2d53bd0fbdfa6",
+      "version": "0.12.1",
+      "sha": "f3e1df7e0572c0119cbb420e1e27ca9af859f91c",
       "checkver": {
         "type": "tag",
         "repo": "https://github.com/readest/readest"
       }
     },
     "test": {
-      "version": "0.11.20",
-      "sha": "1df1505fc5033fc949463c9908f2d53bd0fbdfa6",
+      "version": "0.12.1",
+      "sha": "f3e1df7e0572c0119cbb420e1e27ca9af859f91c",
       "checkver": {
         "type": "tag",
         "repo": "readest/readest"

--- a/apps/readest/pre.sh
+++ b/apps/readest/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.20"
+VERSION="v0.12.1"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)

--- a/apps/readest/pre.test.sh
+++ b/apps/readest/pre.test.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="v0.11.20"
+VERSION="v0.12.1"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `readest` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`readest/readest`](https://github.com/readest/readest) | `0.11.20` → `0.12.1` | [`1df1505`](https://github.com/readest/readest/commit/1df1505fc5033fc949463c9908f2d53bd0fbdfa6) → [`f3e1df7`](https://github.com/readest/readest/commit/f3e1df7e0572c0119cbb420e1e27ca9af859f91c) |
| `test` | [`readest/readest`](https://github.com/readest/readest) | `0.11.20` → `0.12.1` | [`1df1505`](https://github.com/readest/readest/commit/1df1505fc5033fc949463c9908f2d53bd0fbdfa6) → [`f3e1df7`](https://github.com/readest/readest/commit/f3e1df7e0572c0119cbb420e1e27ca9af859f91c) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.12.1 (#5581) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-08-09T01:02:59+08:00Z |
| **Changed** | 1042 files, +74824/-6506 |

📝 Recent Commits

- [`f3e1df7e`](https://github.com/readest/readest/commit/f3e1df7e) release: version 0.12.1 (#5581)
- [`14de4972`](https://github.com/readest/readest/commit/14de4972) fix: fix occasional stuck when dismissing bookshelf menu (#5580)
- [`cf413b2b`](https://github.com/readest/readest/commit/cf413b2b) chore: update agent memories (#5579)
- [`7e07e1b4`](https://github.com/readest/readest/commit/7e07e1b4) fix: highlight swatch colors, window set-title ACL, and debug-build Sentry DSN (#5578)
- [`9b50ceeb`](https://github.com/readest/readest/commit/9b50ceeb) fix(tts): play Media Overlay narration via native AVPlayer on iOS (#5562)
- [`70465cb6`](https://github.com/readest/readest/commit/70465cb6) docs: update screenshots, closes #5368 (#5577)
- [`eaadf544`](https://github.com/readest/readest/commit/eaadf544) Add support for Custom HTTP Headers in Kosync/BookOrbit integrations  (#5570)
- [`ada70fc2`](https://github.com/readest/readest/commit/ada70fc2) feat(reader): summarize annotation counts in the sidebar toolbar (#5576)
- [`dbcae8b2`](https://github.com/readest/readest/commit/dbcae8b2) feat(reader): render math in annotation notes (#5571)
- [`58e234bd`](https://github.com/readest/readest/commit/58e234bd) chore(store): replace Play listing images instead of appending (#5574)

[🔗 View full comparison](https://github.com/readest/readest/compare/1df1505...f3e1df7)

</p></details>

<details><summary>test</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`readest/readest`](https://github.com/readest/readest) |
| **Latest Commit** | release: version 0.12.1 (#5581) |
| **Author** | Huang Xin &lt;chrox.huang@gmail.com&gt; |
| **Date** | 2026-08-09T01:02:59+08:00Z |
| **Changed** | 1042 files, +74824/-6506 |

📝 Recent Commits

- [`f3e1df7e`](https://github.com/readest/readest/commit/f3e1df7e) release: version 0.12.1 (#5581)
- [`14de4972`](https://github.com/readest/readest/commit/14de4972) fix: fix occasional stuck when dismissing bookshelf menu (#5580)
- [`cf413b2b`](https://github.com/readest/readest/commit/cf413b2b) chore: update agent memories (#5579)
- [`7e07e1b4`](https://github.com/readest/readest/commit/7e07e1b4) fix: highlight swatch colors, window set-title ACL, and debug-build Sentry DSN (#5578)
- [`9b50ceeb`](https://github.com/readest/readest/commit/9b50ceeb) fix(tts): play Media Overlay narration via native AVPlayer on iOS (#5562)
- [`70465cb6`](https://github.com/readest/readest/commit/70465cb6) docs: update screenshots, closes #5368 (#5577)
- [`eaadf544`](https://github.com/readest/readest/commit/eaadf544) Add support for Custom HTTP Headers in Kosync/BookOrbit integrations  (#5570)
- [`ada70fc2`](https://github.com/readest/readest/commit/ada70fc2) feat(reader): summarize annotation counts in the sidebar toolbar (#5576)
- [`dbcae8b2`](https://github.com/readest/readest/commit/dbcae8b2) feat(reader): render math in annotation notes (#5571)
- [`58e234bd`](https://github.com/readest/readest/commit/58e234bd) chore(store): replace Play listing images instead of appending (#5574)

[🔗 View full comparison](https://github.com/readest/readest/compare/1df1505...f3e1df7)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
