### PR TITLE
update(apps/dashboard-icons): update latest version to d64ee64

### DIFF
--- a/apps/dashboard-icons/meta.json
+++ b/apps/dashboard-icons/meta.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "variants": {
     "latest": {
-      "version": "03e8f8e",
-      "sha": "03e8f8e22da16ccddf5e14afa90711391357231e",
+      "version": "d64ee64",
+      "sha": "d64ee64282b076fa15e150b32c6880172880dd00",
       "checkver": {
         "type": "sha",
         "repo": "homarr-labs/dashboard-icons"

--- a/apps/dashboard-icons/pre.sh
+++ b/apps/dashboard-icons/pre.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="03e8f8e"
+VERSION="d64ee64"
 
 # Store the current working directory to return back later
 old_pwd=$(pwd)


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `dashboard-icons` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) | `03e8f8e` → `d64ee64` | [`03e8f8e`](https://github.com/homarr-labs/dashboard-icons/commit/03e8f8e22da16ccddf5e14afa90711391357231e) → [`d64ee64`](https://github.com/homarr-labs/dashboard-icons/commit/d64ee64282b076fa15e150b32c6880172880dd00) |


### 🔍 Details

#### `latest`

| Key | Value |
|-----|-------|
| **Repository** | [`homarr-labs/dashboard-icons`](https://github.com/homarr-labs/dashboard-icons) |
| **Latest Commit** | fix(web): revert crossOrigin on Carbon Ads script to restore ads |
| **Author** | Thomas &lt;thomas@ajnart.dev&gt; |
| **Date** | 2026-08-09T00:05:32+08:00Z |
| **Changed** | 82 files, +5983/-1896 |

📝 Recent Commits

- [`d64ee642`](https://github.com/homarr-labs/dashboard-icons/commit/d64ee642) fix(web): revert crossOrigin on Carbon Ads script to restore ads
- [`8c5831c2`](https://github.com/homarr-labs/dashboard-icons/commit/8c5831c2) fix(web): revert crossOrigin on Carbon Ads script to restore ads
- [`122d738b`](https://github.com/homarr-labs/dashboard-icons/commit/122d738b) fix(web): make PostHog MCP analytics actually capture events
- [`984735d8`](https://github.com/homarr-labs/dashboard-icons/commit/984735d8) Merge remote-tracking branch &#39;origin/main&#39; into fix/mcp-analytics-posthog
- [`740efb80`](https://github.com/homarr-labs/dashboard-icons/commit/740efb80) fix(web): address CodeRabbit review findings
- [`070003cc`](https://github.com/homarr-labs/dashboard-icons/commit/070003cc) test(web): assert JSON-RPC results in MCP analytics integration test
- [`1cf34776`](https://github.com/homarr-labs/dashboard-icons/commit/1cf34776) Merge pull request #2890 from homarr-labs/posthog-self-driving/fixweb-filter-firefox-cross-origin-1327f5
- [`2a53d9ed`](https://github.com/homarr-labs/dashboard-icons/commit/2a53d9ed) chore(web): remove dead OTLP log exporter
- [`ee43bbc8`](https://github.com/homarr-labs/dashboard-icons/commit/ee43bbc8) fix(web): also drop Firefox cross-origin $exception noise
- [`6411cc53`](https://github.com/homarr-labs/dashboard-icons/commit/6411cc53) Merge remote-tracking branch &#39;origin/main&#39; into fix/mcp-analytics-posthog

[🔗 View full comparison](https://github.com/homarr-labs/dashboard-icons/compare/03e8f8e...d64ee64)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
