### PR TITLE
update(apps/excalidraw): update dev version to cf212b2

### DIFF
--- a/apps/excalidraw/meta.json
+++ b/apps/excalidraw/meta.json
@@ -21,8 +21,8 @@
       }
     },
     "dev": {
-      "version": "e4ab626",
-      "sha": "e4ab626739f5f163c5eca56190f615643218b61c",
+      "version": "cf212b2",
+      "sha": "cf212b2f3354c09bd6f960b53a9cfb0a3ecbfa58",
       "checkver": {
         "type": "sha",
         "repo": "excalidraw/excalidraw"

--- a/apps/excalidraw/pre.dev.sh
+++ b/apps/excalidraw/pre.dev.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-VERSION="e4ab626"
+VERSION="cf212b2"
 
 # Clone the repository
 mkdir -p app && cd app


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `excalidraw` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `dev` | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) | `e4ab626` → `cf212b2` | [`e4ab626`](https://github.com/excalidraw/excalidraw/commit/e4ab626739f5f163c5eca56190f615643218b61c) → [`cf212b2`](https://github.com/excalidraw/excalidraw/commit/cf212b2f3354c09bd6f960b53a9cfb0a3ecbfa58) |


### 🔍 Details

#### `dev`

| Key | Value |
|-----|-------|
| **Repository** | [`excalidraw/excalidraw`](https://github.com/excalidraw/excalidraw) |
| **Latest Commit** | feat(editor): eyedropper fixes and improvements (#11859) |
| **Author** | David Luzar &lt;5153846+dwelle@users.noreply.github.com&gt; |
| **Date** | 2026-08-09T05:17:26+08:00Z |
| **Changed** | 19 files, +702/-147 |

📝 Recent Commits

- [`cf212b2f`](https://github.com/excalidraw/excalidraw/commit/cf212b2f) feat(editor): eyedropper fixes and improvements (#11859)
- [`4872083c`](https://github.com/excalidraw/excalidraw/commit/4872083c) feat(editor): bucketfill cursor + eyedropper support (#11849)
- [`ea747874`](https://github.com/excalidraw/excalidraw/commit/ea747874) fix(app): remove ViewportStatusFrame debug (#11848)
- [`219571a7`](https://github.com/excalidraw/excalidraw/commit/219571a7) fix(editor): viewportportStatusFrame UI fixes (#11841)

[🔗 View full comparison](https://github.com/excalidraw/excalidraw/compare/e4ab626...cf212b2)

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
