### PR TITLE
update(base/vscode): update latest version to 1.132.1, update stable version to 1.132.1

### DIFF
--- a/base/vscode/Dockerfile
+++ b/base/vscode/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.132.0
+ARG VERSION=1.132.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.132.0 -> 1.132.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.132.1 -> 1.132.1.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/Dockerfile.stable
+++ b/base/vscode/Dockerfile.stable
@@ -2,7 +2,7 @@ FROM debian:12 AS base
 
 FROM base AS deps
 
-ARG VERSION=1.132.0
+ARG VERSION=1.132.1
 
 # deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -17,7 +17,7 @@ RUN set -eux; \
     code_url=https://update.code.visualstudio.com; \
     code_target=$([ "$arch" = "amd64" ] && echo "cli-linux-x64" || ([ "$arch" = "arm64" ] && echo "cli-linux-arm64" )); \
     if [ -z "$code_target" ]; then echo "Unsupported architecture: $arch" && exit 1; fi; \
-    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.132.0 -> 1.132.0.0
+    # 处理版本号，如果只有 major 和 minor，则补全 patch 版本为 0，例如 1.132.1 -> 1.132.1.0
     if expr "$VERSION" : '^[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then VERSION="${VERSION}.0"; fi; \
     download_url="${code_url}/${VERSION}/${code_target}/stable"; \
     echo "Downloading code from $download_url"; \

--- a/base/vscode/meta.json
+++ b/base/vscode/meta.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "variants": {
     "latest": {
-      "version": "1.132.0",
-      "sha": "df53daabb18cd157bdb08c7f01c34df936cf12f4",
+      "version": "1.132.1",
+      "sha": "c2d1b13fdc4a77628e5f3bb70173351c8f2fbad1",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",
@@ -20,8 +20,8 @@
       }
     },
     "stable": {
-      "version": "1.132.0",
-      "sha": "df53daabb18cd157bdb08c7f01c34df936cf12f4",
+      "version": "1.132.1",
+      "sha": "c2d1b13fdc4a77628e5f3bb70173351c8f2fbad1",
       "checkver": {
         "type": "tag",
         "repo": "microsoft/vscode",


### PR DESCRIPTION
## 🚀 Auto-generated PR to update `vscode` versions

### 📋 Summary

| Variant Name | Source | Version | Revision |
|--------------|--------|---------|----------|
| `latest` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.132.0` → `1.132.1` | [`df53daa`](https://github.com/microsoft/vscode/commit/df53daabb18cd157bdb08c7f01c34df936cf12f4) → [`c2d1b13`](https://github.com/microsoft/vscode/commit/c2d1b13fdc4a77628e5f3bb70173351c8f2fbad1) |
| `stable` | [`microsoft/vscode`](https://github.com/microsoft/vscode) | `1.132.0` → `1.132.1` | [`df53daa`](https://github.com/microsoft/vscode/commit/df53daabb18cd157bdb08c7f01c34df936cf12f4) → [`c2d1b13`](https://github.com/microsoft/vscode/commit/c2d1b13fdc4a77628e5f3bb70173351c8f2fbad1) |


### 🔍 Details

<details open><summary>latest</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Fix tests (#90) |
| **Author** | Paul Wang &lt;Paul.Wang@microsoft.com&gt; |
| **Date** | 2026-08-08T01:44:35+08:00Z |
| **Changed** | 28 files, +1101/-94 |

📝 Recent Commits

- [`c2d1b13fdc4`](https://github.com/microsoft/vscode/commit/c2d1b13fdc4) Fix tests (#90)
- [`5b61b500b64`](https://github.com/microsoft/vscode/commit/5b61b500b64) More compile fixes (#89)
- [`8cadc4d0f99`](https://github.com/microsoft/vscode/commit/8cadc4d0f99) Type cast to fix type error (#88)
- [`af3a976e194`](https://github.com/microsoft/vscode/commit/af3a976e194) Fix for MSRC 127004 - domainMatcher.ts - SSRF via IPv4-mapped IPv6 literal bypass (#87)
- [`11b254d36e9`](https://github.com/microsoft/vscode/commit/11b254d36e9) Fix for MSRC 122104: webPageLoader.ts - Zero-click OS protocol launch via webview- #83 (#86)
- [`ae7a28076f3`](https://github.com/microsoft/vscode/commit/ae7a28076f3) Always return copies of buffers to extensions (#82)
- [`8af0773d5eb`](https://github.com/microsoft/vscode/commit/8af0773d5eb) Fix acceptEdits workspace boundary bypass (MSRC 115876) (#84)
- [`3154a68fc15`](https://github.com/microsoft/vscode/commit/3154a68fc15) Fix terminal workspace trust bypass (#77)
- [`ef3ccf91228`](https://github.com/microsoft/vscode/commit/ef3ccf91228) server: Block privileged URL payload options (#78)
- [`4df36e5293a`](https://github.com/microsoft/vscode/commit/4df36e5293a) Bump version to 1.132.1 (#81)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/df53daa...c2d1b13)

</p></details>

<details><summary>stable</summary><p>

| Key | Value |
|-----|-------|
| **Repository** | [`microsoft/vscode`](https://github.com/microsoft/vscode) |
| **Latest Commit** | Fix tests (#90) |
| **Author** | Paul Wang &lt;Paul.Wang@microsoft.com&gt; |
| **Date** | 2026-08-08T01:44:35+08:00Z |
| **Changed** | 28 files, +1101/-94 |

📝 Recent Commits

- [`c2d1b13fdc4`](https://github.com/microsoft/vscode/commit/c2d1b13fdc4) Fix tests (#90)
- [`5b61b500b64`](https://github.com/microsoft/vscode/commit/5b61b500b64) More compile fixes (#89)
- [`8cadc4d0f99`](https://github.com/microsoft/vscode/commit/8cadc4d0f99) Type cast to fix type error (#88)
- [`af3a976e194`](https://github.com/microsoft/vscode/commit/af3a976e194) Fix for MSRC 127004 - domainMatcher.ts - SSRF via IPv4-mapped IPv6 literal bypass (#87)
- [`11b254d36e9`](https://github.com/microsoft/vscode/commit/11b254d36e9) Fix for MSRC 122104: webPageLoader.ts - Zero-click OS protocol launch via webview- #83 (#86)
- [`ae7a28076f3`](https://github.com/microsoft/vscode/commit/ae7a28076f3) Always return copies of buffers to extensions (#82)
- [`8af0773d5eb`](https://github.com/microsoft/vscode/commit/8af0773d5eb) Fix acceptEdits workspace boundary bypass (MSRC 115876) (#84)
- [`3154a68fc15`](https://github.com/microsoft/vscode/commit/3154a68fc15) Fix terminal workspace trust bypass (#77)
- [`ef3ccf91228`](https://github.com/microsoft/vscode/commit/ef3ccf91228) server: Block privileged URL payload options (#78)
- [`4df36e5293a`](https://github.com/microsoft/vscode/commit/4df36e5293a) Bump version to 1.132.1 (#81)

[🔗 View full comparison](https://github.com/microsoft/vscode/compare/df53daa...c2d1b13)

</p></details>

### ⚡ Auto-merge

This PR is marked for auto-merge and will be automatically merged if all checks pass.
